### PR TITLE
Update pitt_city_council

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - 3.5
   - 3.6
   - 3.7-dev
+install:
+  - pip install -U pip wheel setuptools
+  - pip install -r requirements.txt
 script:
   - isort --check-only --diff || exit 1
   - yapf --diff --recursive ./city_scrapers/ ./tests/ || exit 1

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ scrapy = "*"
 legistar = {git = "https://github.com/opencivicdata/python-legistar-scraper"}
 python-dateutil = "*"
 city-scrapers-core = {extras = ["aws"],version = "*"}
+scrapy-sentry = "*"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f6c10775efffe807957ab1fc13595eab821c33fdaad5ed90859cd386c5f50311"
+            "sha256": "020b974a05d2f72c08f5d80e778f08b0f01254edffa606bf5a08ce349632f095"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -299,6 +299,13 @@
             ],
             "version": "==1.5.0"
         },
+        "raven": {
+            "hashes": [
+                "sha256:3fa6de6efa2493a7c827472e984ce9b020797d0da16f1db67197bcc23c8fae54",
+                "sha256:44a13f87670836e153951af9a3c80405d36b43097db869a36e92809673692ce4"
+            ],
+            "version": "==6.10.0"
+        },
         "requests": {
             "hashes": [
                 "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
@@ -321,6 +328,13 @@
             ],
             "index": "pypi",
             "version": "==1.6.0"
+        },
+        "scrapy-sentry": {
+            "hashes": [
+                "sha256:4c78e0fb5a5940639f11ae2a1fb28d4ea1a41180d88289efc6d8e39e1e14227f"
+            ],
+            "index": "pypi",
+            "version": "==0.9.0"
         },
         "service-identity": {
             "hashes": [

--- a/city_scrapers/settings/prod.py
+++ b/city_scrapers/settings/prod.py
@@ -23,6 +23,7 @@ ITEM_PIPELINES = {
 # for S3 and Azure respectively.
 
 EXTENSIONS = {
+    "scrapy_sentry.extensions.Errors": 10,
     "city_scrapers_core.extensions.S3StatusExtension": 100,
     "scrapy.extensions.closespider.CloseSpider": None,
 }

--- a/city_scrapers/spiders/pitt_city_council.py
+++ b/city_scrapers/spiders/pitt_city_council.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
-from city_scrapers_core.constants import NOT_CLASSIFIED
+from city_scrapers_core.constants import CITY_COUNCIL, COMMITTEE
+from city_scrapers_core.items import Meeting
 from city_scrapers_core.spiders import LegistarSpider
-from legistar.events import LegistarEventsScraper
 
 
 class PittCityCouncilSpider(LegistarSpider):
@@ -14,86 +14,47 @@ class PittCityCouncilSpider(LegistarSpider):
     # Add the titles of any links not included in the scraped results
     link_types = []
 
-    def parse(self, response):
+    def parse_legistar(self, events):
         """
-        `parse` should always `yield` a dict that follows the `Open Civic Data
-        event standard <http://docs.opencivicdata.org/en/latest/data/event.html>`.
+        `parse_legistar` should always `yield` Meeting items.
+
         Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
         needs.
         """
-        events = self._make_legistar_call()
-        return self._parse_events(events)
+        for event, _ in events:
+            start = self.legistar_start(event)
+            title = event.get("Name")
+            meeting = Meeting(
+                title=title,
+                description=self._parse_description(event),
+                classification=self._parse_classification(title),
+                start=start,
+                end=self._parse_end(start),
+                all_day=False,
+                time_notes="Estimated 3 hour meeting length",
+                location=self._parse_location(event),
+                links=self.legistar_links(event),
+                source=self._parse_source(event),
+            )
 
-    def _make_legistar_call(self, since=None):
-        les = LegistarEventsScraper(requests_per_minute=0)
-        les.EVENTSPAGE = 'https://pittsburgh.legistar.com/Calendar.aspx'
-        les.BASE_URL = 'https://pittsburgh.legistar.com'
-        if not since:
-            since = datetime.today().year
-        return les.events(since=since)
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
 
-    def _parse_events(self, events):
-        for item, _ in events:
-            name = self._parse_name(item)
-            data = {
-                '_type': 'event',
-                'name': name,
-                # OCD standard wants 'name', but city_scrapers_core wants 'title'
-                'title': name,
-                'description': self._parse_description(item),
-                'timezone': self.timezone,
-                'start': self._parse_start(item),
-                'end': self._parse_end(item),
-                'all_day': self._parse_all_day(item),
-                'time_notes': 'Estimated three-hour meeting length',
-                'location': self._parse_location(item),
-                'source': self._parse_sources(item),
-                'documents': self._parse_documents(item),
-                'links': self.legistar_links(item),
-                'classification': self._parse_classification(item),
-            }
-            data['status'] = self._get_status(data, item.get('Meeting Location'))
-            data['id'] = self._get_id(data)
-            yield data
+            yield meeting
 
-    def _parse_documents(self, item):
+    def _parse_end(self, start):
+        return start + timedelta(hours=3)
+
+    def _parse_description(self, item):
         """
-        Returns meeting details, agenda, minutes, video, if available.
+        Parse or generate meeting description.
+        In Pittsburgh's case the meeting info comes on a new line
+        in the location section, italicized.
         """
-        documents = []
-        details = item.get('Meeting Details')
-        if type(details) == dict:
-            documents.append({
-                'note': 'Meeting Details',
-                'url': details.get('url'),
-                'media_type': 'text',
-                'date': ''
-            })
-        agenda = item.get('Agenda')
-        if type(agenda) == dict:
-            documents.append({
-                'note': 'Agenda',
-                'url': agenda.get('url'),
-                'media_type': 'text',
-                'date': ''
-            })
-        minutes = item.get('Minutes')
-        if type(minutes) == dict:
-            documents.append({
-                'note': 'Minutes',
-                'url': minutes.get('url'),
-                'media_type': 'text',
-                'date': ''
-            })
-        video = item.get('Video')
-        if type(video) == dict:
-            documents.append({
-                'note': 'Video',
-                'url': video.get('url'),
-                'media_type': 'video',
-                'date': ''
-            })
-        return documents
+        try:
+            return item.get('Meeting Location').split('\n')[1].split('--em--')[1]
+        except IndexError:
+            return ""
 
     def _parse_location(self, item):
         """
@@ -110,62 +71,15 @@ class PittCityCouncilSpider(LegistarSpider):
             'neighborhood': ''
         }
 
-    def _parse_all_day(self, item):
-        """
-        Parse or generate all-day status. Defaults to false.
-        This currently isn't denoted on the council site;
-        we can update this function if that changes.
-        """
-        return False
-
-    def _parse_name(self, item):
-        """
-        Parse or generate event name.
-        """
-        name = item.get('Name')
-        if 'City Council' in name:
-            name = name + ' : meeting'
-        return name
-
-    def _parse_start(self, item):
-        """
-        Return the start date and time as a localized datetime object.
-        """
-        time = item.get('Meeting Time', None)
-        date = item.get('Meeting Date', None)
-        if date and time:
-            time_string = '{0} {1}'.format(date, time)
-            return datetime.strptime(time_string, '%m/%d/%Y %I:%M %p')
-        return None
-
-    def _parse_end(self, item):
-        """
-        No end times are listed, so estimate the end time to
-        be 3 hours after the start time.
-        """
-        return self._parse_start(item) + timedelta(hours=3)
-
-    def _parse_sources(self, item):
-        """
-        Parse sources.
-        """
-        try:
-            url = item.get('Meeting Details').get('url')
-        except (ValueError, AttributeError):
-            url = 'https://pittsburgh.legistar.com/Calendar.aspx'
-        return [{'url': url, 'note': ''}]
-
-    def _parse_description(self, item):
-        """
-        Parse or generate meeting description.
-        In Pittsburgh's case the meeting info comes on a new line
-        in the location section, italicized.
-        """
-        try:
-            return item.get('Meeting Location').split('\n')[1].split('--em--')[1]
-        except IndexError:
-            return 'no description'
-
-    def _parse_classification(self, item):
+    def _parse_classification(self, title):
         """Parse or generate classification from allowed options."""
-        return NOT_CLASSIFIED
+        if "committee" in title.lower():
+            return COMMITTEE
+        return CITY_COUNCIL
+
+    def _parse_source(self, item):
+        """Parse source from meeting details if available"""
+        default_source = "{}/Calendar.aspx".format(self.base_url)
+        if isinstance(item.get("Meeting Details"), dict):
+            return item["Meeting Details"].get("url", default_source)
+        return default_source

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ raven==6.10.0
 requests==2.21.0
 s3transfer==0.2.0
 scrapy==1.6.0
+scrapy-sentry==0.9.0
 service-identity==18.1.0
 six==1.12.0
 twisted==19.2.0

--- a/tests/test_pitt_city_council.py
+++ b/tests/test_pitt_city_council.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from os.path import dirname, join
 
 import pytest
-from city_scrapers_core.constants import NOT_CLASSIFIED
+from city_scrapers_core.constants import COMMITTEE, TENTATIVE
 from freezegun import freeze_time
 
 from city_scrapers.spiders.pitt_city_council import PittCityCouncilSpider
@@ -15,7 +15,7 @@ with open(join(dirname(__file__), "files", "pitt_city_council.json"), "r") as f:
     test_response = json.load(f)
 
 spider = PittCityCouncilSpider()
-parsed_items = [item for item in spider._parse_events(test_response)]
+parsed_items = [item for item in spider.parse_legistar(test_response)]
 
 freezer.stop()
 
@@ -25,7 +25,7 @@ def test_title():
 
 
 def test_description():
-    assert parsed_items[0]["description"] == "no description"
+    assert parsed_items[0]["description"] == ""
 
 
 def test_start():
@@ -37,7 +37,7 @@ def test_end():
 
 
 def test_time_notes():
-    assert parsed_items[0]["time_notes"] == "Estimated three-hour meeting length"
+    assert parsed_items[0]["time_notes"] == "Estimated 3 hour meeting length"
 
 
 def test_id():
@@ -45,7 +45,7 @@ def test_id():
 
 
 def test_status():
-    assert parsed_items[0]["status"] == "tentative"
+    assert parsed_items[0]["status"] == TENTATIVE
 
 
 def test_location():
@@ -58,7 +58,7 @@ def test_location():
 
 
 def test_source():
-    assert parsed_items[0]["source"][0].get('url') == (
+    assert parsed_items[0]["source"] == (
         "https://pittsburgh.legistar.com/MeetingDeta"
         "il.aspx?ID=681042&GUID=631BD673-830F-4759-"
         "9DDE-EB16B3F1E681&Options=info&Search="
@@ -76,7 +76,7 @@ def test_links():
 
 
 def test_classification():
-    assert parsed_items[0]["classification"] == NOT_CLASSIFIED
+    assert parsed_items[0]["classification"] == COMMITTEE
 
 
 @pytest.mark.parametrize("item", parsed_items)


### PR DESCRIPTION
Updates `pitt_city_council` to work with the `city_scrapers_core` setup, moving some of the functionality into the generic `LegistarSpider`.

Also re-adds `scrapy-sentry` if it ends up working on 3.7