### PR TITLE
Fixing datetime mocking issue with port authority test

### DIFF
--- a/tests/test_alle_port_authority.py
+++ b/tests/test_alle_port_authority.py
@@ -14,11 +14,10 @@ test_response = file_response(
         "https://www.portauthority.org/paac/CompanyInfoProjects/BoardofDirectors/MeetingAgendasResolutions.aspx"  # noqa
     ),
 )
-spider = AllePortAuthoritySpider()
-
 freezer = freeze_time("2019-01-23")
 freezer.start()
 
+spider = AllePortAuthoritySpider()
 parsed_items = [item for item in spider.parse(test_response)]
 
 freezer.stop()


### PR DESCRIPTION
And running YAPF for good measure

The port authority spider is using the `self.year` field from the `CityScrapersSpider` parent class, which is initialized based on the current date time in the `CityScrapersSpider` constructor. Therefore, the scraper construction needs to happen within the bounds of `freezer.start()/freezer.end()` in the test case in order for `self.year` to be affected by the mock.