### PR TITLE
Fix pa_liquorboard

### DIFF
--- a/tests/files/pa_liquorboard.html
+++ b/tests/files/pa_liquorboard.html
@@ -1,21 +1,20 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html dir="ltr" lang="en-US">
-
-<head><meta http-equiv="X-UA-Compatible" content="IE=10" /><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, minimum-scale=1.0" /><meta http-equiv="Expires" content="0" /><meta name="GENERATOR" content="Microsoft SharePoint" /><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><meta http-equiv="Expires" content="0" /><meta name="HandheldFriendly" content="True" /><meta name="MobileOptimized" content="320" /><meta name="format-detection" content="telephone=yes" /><meta name="robots" content="index, follow" /><meta name="viewport" content="width = device-width, initial-scale=1.0" /><meta name="msapplication-TileColor" content="#ffffff" /><meta name="msapplication-TileImage" content="/_layouts/15/images/SharePointMetroAppTile.png" /><meta name="msapplication-TileColor" content="#0072C6" /><title>
+<!-- saved from url=(0064)https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx -->
+<html dir="ltr" lang="en-US" data-whatinput="mouse" data-whatintent="mouse" class=" whatinput-types-initial whatinput-types-mouse" style="height: 100%;"><script type="text/javascript" async="" src="./PLCB Public Meetings_files/analytics.js"></script><script async="" src="./PLCB Public Meetings_files/gtm.js"></script><script src="chrome-extension://ljdobmomdgdljniojadhoplhkpialdid/page/prompt.js"></script><script src="chrome-extension://ljdobmomdgdljniojadhoplhkpialdid/page/runScript.js"></script><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta http-equiv="X-UA-Compatible" content="IE=10"><meta name="viewport" content="width=device-width, minimum-scale=1.0"><meta http-equiv="Expires" content="0"><meta name="GENERATOR" content="Microsoft SharePoint"><meta http-equiv="Expires" content="0"><meta name="HandheldFriendly" content="True"><meta name="MobileOptimized" content="320"><meta name="format-detection" content="telephone=yes"><meta name="robots" content="index, follow"><meta name="viewport" content="width = device-width, initial-scale=1.0"><meta name="msapplication-TileColor" content="#ffffff"><meta name="msapplication-TileImage" content="/_layouts/15/images/SharePointMetroAppTile.png"><meta name="msapplication-TileColor" content="#0072C6"><title>
 	
     
     
     PLCB Public Meetings
     
     
-</title><link rel="stylesheet" type="text/css" href="/_layouts/15/1033/styles/Themable/corev15.css?rev=2bpHeX9U8DH09TB5zpJcsQ%3D%3D"/>
-<script type="text/javascript" src="/_layouts/15/init.js?rev=Xpo7ARBt8xBROO1h5n3s6g%3D%3D"></script>
-<script type="text/javascript" src="/_layouts/15/1033/initstrings.js?rev=S11vfGURQYVuACMEY0tLTg%3D%3D"></script>
-<script type="text/javascript" src="/_layouts/15/clienttemplates.js?rev=NjHQZTfQs%2BiDIjz4PK%2FeWg%3D%3D"></script>
-<script type="text/javascript" src="/ScriptResource.axd?d=Q_4HnoqIbCr8P804u6-qVGpWjKw4byKBuRkOXpG3Q2OmJ_CFc8h01_NNNo5y5ectYxhGEKtWZuN-IbeVHR9mnneMrbKKN9NHWXJ2w6r5NafVF129WKXjzBl53sYDndszQ65XUDU5GP2Id6c3y1i0S3qgBCppA3SXt0ge_3Jv5H01&amp;t=ffffffff999c3159"></script>
-<script type="text/javascript" src="/_layouts/15/blank.js?rev=ZaOXZEobVwykPO9g8hq%2F8A%3D%3D"></script>
-<script type="text/javascript" src="/ScriptResource.axd?d=ngqjq1ivnrzUkcuy-OUMFwWVnJCKUT0y52uKrP_JLTxotKUZ904r37Hlnh_pznj6WQVwv8gqzB9W9n_aLc0ru2K9YrI8SbAYqaYTi6PHWFUmWAWk228FHGWRRk2a_T0ToizfkB37LPZe78dlXwTwhchxcT2fzkUspHpHCVAnFNiCR9t78mFGu4S5iDCX-vSX0&amp;t=ffffffff999c3159"></script>
-<script type="text/javascript" src="/_layouts/15/calloutusagecontrolscript.js?rev=sdjbothwP3Vzhu0M4k0%2B8A%3D%3D"></script>
+</title><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/corev15.css">
+<script type="text/javascript" src="./PLCB Public Meetings_files/init.js"></script>
+<script type="text/javascript" src="./PLCB Public Meetings_files/initstrings.js"></script>
+<script type="text/javascript" src="./PLCB Public Meetings_files/clienttemplates.js"></script>
+<script type="text/javascript" src="./PLCB Public Meetings_files/ScriptResource.axd"></script>
+<script type="text/javascript" src="./PLCB Public Meetings_files/blank.js"></script>
+<script type="text/javascript" src="./PLCB Public Meetings_files/ScriptResource(1).axd"></script>
+<script type="text/javascript" src="./PLCB Public Meetings_files/calloutusagecontrolscript.js"></script>
 <script type="text/javascript">RegisterSod("strings.js", "\u002f_layouts\u002f15\u002f1033\u002fstrings.js?rev=xXYZY4hciX287lShPZuClw\u00253D\u00253D");</script>
 <script type="text/javascript">RegisterSod("sp.init.js", "\u002f_layouts\u002f15\u002fsp.init.js?rev=jvJC3Kl5gbORaLtf7kxULQ\u00253D\u00253D");</script>
 <script type="text/javascript">RegisterSod("sp.res.resx", "\u002f_layouts\u002f15\u002fScriptResx.ashx?culture=en\u00252Dus\u0026name=SP\u00252ERes\u0026rev=yNk\u00252FhRzgBn40LJVP\u00252BqfgdQ\u00253D\u00253D");</script>
@@ -27,7 +26,7 @@
 <script type="text/javascript">RegisterSod("sharing.js", "\u002f_layouts\u002f15\u002fsharing.js?rev=XxxHIxIIc8BsW9ikVc6dgA\u00253D\u00253D");RegisterSodDep("sharing.js", "strings.js");RegisterSodDep("sharing.js", "mQuery.js");RegisterSodDep("sharing.js", "core.js");</script>
 <script type="text/javascript">RegisterSod("suitelinks.js", "\u002f_layouts\u002f15\u002fsuitelinks.js?rev=REwVU5jSsadDdOZlCx4wpA\u00253D\u00253D");RegisterSodDep("suitelinks.js", "strings.js");RegisterSodDep("suitelinks.js", "core.js");</script>
 <script type="text/javascript">RegisterSod("sp.runtime.js", "\u002f_layouts\u002f15\u002fsp.runtime.js?rev=5f2WkYJoaxlIRdwUeg4WEg\u00253D\u00253D");RegisterSodDep("sp.runtime.js", "sp.res.resx");</script>
-<script type="text/javascript">RegisterSod("sp.js", "\u002f_layouts\u002f15\u002fsp.js?rev=qpivgvUSRkZ4OiXMzDldMQ\u00253D\u00253D");RegisterSodDep("sp.js", "sp.runtime.js");RegisterSodDep("sp.js", "sp.ui.dialog.js");RegisterSodDep("sp.js", "sp.res.resx");</script>
+<script type="text/javascript">RegisterSod("sp.js", "\u002f_layouts\u002f15\u002fsp.js?rev=BJ9b7Ak8FOS3NwGiaTXOjA\u00253D\u00253D");RegisterSodDep("sp.js", "sp.runtime.js");RegisterSodDep("sp.js", "sp.ui.dialog.js");RegisterSodDep("sp.js", "sp.res.resx");</script>
 <script type="text/javascript">RegisterSod("userprofile", "\u002f_layouts\u002f15\u002fsp.userprofiles.js?rev=p5tCOm\u00252FlHUwcfll7W3pKNw\u00253D\u00253D");RegisterSodDep("userprofile", "sp.runtime.js");</script>
 <script type="text/javascript">RegisterSod("followingcommon.js", "\u002f_layouts\u002f15\u002ffollowingcommon.js?rev=jWqEDmcjCSPmnQw2ZIfItQ\u00253D\u00253D");RegisterSodDep("followingcommon.js", "strings.js");RegisterSodDep("followingcommon.js", "sp.js");RegisterSodDep("followingcommon.js", "userprofile");RegisterSodDep("followingcommon.js", "core.js");RegisterSodDep("followingcommon.js", "mQuery.js");</script>
 <script type="text/javascript">RegisterSod("profilebrowserscriptres.resx", "\u002f_layouts\u002f15\u002fScriptResx.ashx?culture=en\u00252Dus\u0026name=ProfileBrowserScriptRes\u0026rev=J5HzNnB\u00252FO1Id\u00252FGI18rpRcw\u00253D\u00253D");</script>
@@ -41,7 +40,7 @@
 <script type="text/javascript">RegisterSod("dragdrop.js", "\u002f_layouts\u002f15\u002fdragdrop.js?rev=xyQu9SPqkjO4R2\u00252BS3IwO8Q\u00253D\u00253D");RegisterSodDep("dragdrop.js", "strings.js");</script>
 <script type="text/javascript">RegisterSod("filePreview.js", "\u002f_layouts\u002f15\u002ffilepreview.js?rev=x65YvH2QsTduwOd9pyUEaA\u00253D\u00253D");RegisterSodDep("filePreview.js", "core.js");</script>
 <script type="text/javascript">RegisterSod("sp.search.apps.js", "\u002f_layouts\u002f15\u002fsp.search.apps.js?rev=S7HV1yIlZGPjfThyPwuvJw\u00253D\u00253D");</script>
-<link type="text/xml" rel="alternate" href="/About-Us/Board/_vti_bin/spsdisco.aspx" />
+<link type="text/xml" rel="alternate" href="https://www.lcb.pa.gov/About-Us/Board/_vti_bin/spsdisco.aspx">
     
     
     
@@ -49,9 +48,9 @@
     
     
     
-    <link rel="canonical" href="https://www.lcb.pa.gov:443/About-Us/Board/Pages/Public-Meetings.aspx" />
+    <link rel="canonical" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx">
     
-    <![CDATA[ [if IE 9] ]]>
+    <!--[CDATA[ [if IE 9] ]]-->
     <style type="text/css">//<![CDATA[
          .ms-core-animation-transparent {
             opacity: 0;
@@ -74,7 +73,7 @@
 
         //]] >
     //]]></style>
-    <![CDATA[ [endif] ]]>
+    <!--[CDATA[ [endif] ]]-->
     <!--[if lte IE 8]>
     <style type="text/css">//<![CDATA[
     .ms-core-animation-transparent,
@@ -106,7 +105,7 @@
 
         
     //]]></script>
-    <!-- Start Master Page Assets --><link rel='stylesheet' type='text/css' href='//assets.apps.pa.gov/SP2013v1/Enterprise/CSS/foundation.min.css?Ver=2' /><link rel='stylesheet' type='text/css' href='//assets.apps.pa.gov/SP2013v1/Enterprise/CSS/font-awesome.min.css?Ver=2' /><link rel='stylesheet' type='text/css' href='//assets.apps.pa.gov/SP2013v1/Enterprise/CSS/PAI_New_Custom.css?Ver=2' /><link rel='stylesheet' type='text/css' href='//assets.apps.pa.gov/SP2013v1/Enterprise/CSS/custom_icon_i8.min.css?Ver=2' /><link rel='stylesheet' type='text/css' href='//assets.apps.pa.gov/SP2013v1/Enterprise/CSS/enterprise.css?Ver=3' /><link rel='stylesheet' type='text/css' href='//assets.apps.pa.gov/SP2013v1/Enterprise/CSS/print.css?Ver=3' /><script src='//assets.apps.pa.gov/SP2013v1/Enterprise/JS/jquery.js?Ver=2'></script><script src='//assets.apps.pa.gov/SP2013v1/Enterprise/JS/what-input.js?Ver=2'></script><script src='//assets.apps.pa.gov/SP2013v1/Enterprise/JS/foundation.min.js?Ver=2'></script><script src='//assets.apps.pa.gov/SP2013v1/Enterprise/JS/Enterprise.js?Ver=3'></script><script src='//assets.apps.pa.gov/SP2013v1/Enterprise/JS/jquery.cookie.js?Ver=2'></script><script src='//assets.apps.pa.gov/SP2013v1/Enterprise/JS/fontsizer.js?Ver=2'></script><!-- End Master Page Assets --><!-- Google Search Key --><script>function googleID(key) {key = '007572080359491747877:pxfkaqmnjze';return key}</script><!-- End Google Search Key --><!-- Google Tag Manager --><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-MM4PSF');</script><!-- End Google Tag Manager --><!-- Google Webmaster Verification Tag --><meta name="google-site-verification" content="Tt293AUOBjZQYjeVzVcvxI4PYje2gJMEaNchepmuPVY" /><!-- End Google Webmaster Verification Tag --><link href='../../../_layouts/15/PA.SpEnterprise.TopNav/css/TopNav.css?Ver=1' rel='stylesheet' /><script src='../../../_layouts/15/PA.SpEnterprise.TopNav/js/TopNav.js?Ver=1'></script><link id='favicon' rel='shortcut icon' href='https://www.lcb.pa.gov/PublishingImages/Keystone_gold.png' /> <link rel='stylesheet' type='text/css' href='../../_layouts/15/PA.SpEnterprise.IconBar/css/IconBar.css?v=4' /><link href='../_layouts/15/PA.SpEnterprise.IconBar/css/slick-theme-icon.css?v=2' rel='stylesheet' /><link href='../_layouts/15/PA.SpEnterprise.IconBar/css/slick.css?v=1' rel='stylesheet' /><script src='../../_layouts/15/PA.SpEnterprise.IconBar/js/IconBar.js?v=3'></script><script src='../../_layouts/15/PA.SpEnterprise.IconBar/js/slick.js?v=1'></script><meta property="og:type" content="article" /><meta property="og:title" content="PLCB Public Meetings" /><meta property="og:image" content="https://www.lcb.pa.gov/PublishingImages/Keystone_gold.png" /><meta property="og:site_name" content="Pennsylvania Liquor Control Board" /><!-- Begin Structured Data --><script type="application/ld+json"> {"@context" : "http://schema.org","@type" : "Organization","name" : "PLCB","url" : "https://www.lcb.pa.gov","sameAs" : ["https://www.facebook.com/PAAlcoholEducation/","https://www.linkedin.com/company/pennsylvania-liquor-control-board","https://www.youtube.com/channel/UCNDGYPGOuvy4lP3PDiLgfgQ"]} </script><!-- End Structured Data --><link href='../../../_layouts/15/PA.SpEnterprise.AgencyFooter/css/AgencyFooter.css' rel='stylesheet' /><link href='../../../_layouts/15/PA.SpEnterprise.EnterpriseFooter/css/EnterpriseFooter.css' rel='stylesheet' /><!-- Custom Subsite Header Image --> <style type="text/css" rel="stylesheet">                        #wrap.Home .banner {
+    <!-- Start Master Page Assets --><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/foundation.min.css"><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/PAI_New_Custom.css"><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/custom_icon_i8.min.css"><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/enterprise.css"><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/pai-font.min.css"><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/print.css"><script src="./PLCB Public Meetings_files/jquery.js"></script><script src="./PLCB Public Meetings_files/what-input.js"></script><script src="./PLCB Public Meetings_files/foundation.min.js"></script><script src="./PLCB Public Meetings_files/enterprise.js"></script><script src="./PLCB Public Meetings_files/jquery.cookie.js"></script><script src="./PLCB Public Meetings_files/fontsizer.js"></script><!-- End Master Page Assets --><!-- Google Search Key --><script>function googleID(key) {key = '007572080359491747877:pxfkaqmnjze';return key}</script><!-- End Google Search Key --><!-- Google Tag Manager --><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-MM4PSF');</script><!-- End Google Tag Manager --><!-- Google Webmaster Verification Tag --><meta name="google-site-verification" content="Tt293AUOBjZQYjeVzVcvxI4PYje2gJMEaNchepmuPVY"><!-- End Google Webmaster Verification Tag --><link href="./PLCB Public Meetings_files/TopNav.css" rel="stylesheet"><script src="./PLCB Public Meetings_files/TopNav.js"></script><link id="favicon" rel="shortcut icon" href="https://www.lcb.pa.gov/PublishingImages/Keystone_gold.png"> <link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/IconBar.css"><link href="./PLCB Public Meetings_files/slick-theme-icon.css" rel="stylesheet"><link href="./PLCB Public Meetings_files/slick.css" rel="stylesheet"><script src="./PLCB Public Meetings_files/IconBar.js"></script><script src="./PLCB Public Meetings_files/slick.js"></script><meta property="og:type" content="article"><meta property="og:title" content="PLCB Public Meetings"><meta property="og:image" content="https://www.lcb.pa.gov/PublishingImages/Keystone_gold.png"><meta property="og:site_name" content="Pennsylvania Liquor Control Board"><!-- Begin Structured Data --><script type="application/ld+json"> {"@context" : "http://schema.org","@type" : "Organization","name" : "PLCB","url" : "https://www.lcb.pa.gov","sameAs" : ["https://www.facebook.com/PAAlcoholEducation/","https://www.linkedin.com/company/pennsylvania-liquor-control-board","https://www.youtube.com/channel/UCNDGYPGOuvy4lP3PDiLgfgQ"]} </script><!-- End Structured Data --><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/TopBarGray.css"><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/AgencyFooter.css"><link href="./PLCB Public Meetings_files/EnterpriseFooter.css" rel="stylesheet"><!-- Custom Subsite Header Image --> <style type="text/css" rel="stylesheet">                        #wrap.Home .banner {
                         	background: url('https://www.lcb.pa.gov/banners/banner1.jpg') center no-repeat;
                         }
 
@@ -131,32 +130,32 @@
                                 background: none;
                         }
                     </style>
-                    <!-- End Custom Subsite Header Image --><!-- Start Agency Assets --><link rel='stylesheet' type='text/css' href='//www.lcb.pa.gov/Style%20Library/Agency/css/overwrites.css?Ver=4' /><link rel='stylesheet' type='text/css' href='//www.lcb.pa.gov/Style%20Library/Agency/css/AgencyFonts.css?Ver=2' /><script src='//www.lcb.pa.gov/Style%20Library/Agency/js/overwrites.js?Ver=2'></script><!-- End Agency Assets --><!-- Start Agency Additional Assets --><!-- End Agency Additional Assets --></head>
-<body onhashchange="if (typeof(_spBodyOnHashChange) != 'undefined') _spBodyOnHashChange();"><form method="post" action="./Public-Meetings.aspx" onsubmit="javascript:return WebForm_OnSubmit();" id="aspnetForm">
+                    <!-- End Custom Subsite Header Image --><!-- Start Agency Assets --><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/overwrites.css"><link rel="stylesheet" type="text/css" href="./PLCB Public Meetings_files/AgencyFonts.css"><script src="./PLCB Public Meetings_files/overwrites.js"></script><!-- End Agency Assets --><!-- Start Agency Additional Assets --><!-- End Agency Additional Assets --><link type="text/css" rel="stylesheet" charset="UTF-8" href="./PLCB Public Meetings_files/translateelement.css"><script type="text/javascript" charset="UTF-8" src="./PLCB Public Meetings_files/main.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/strings.js"></script><meta class="foundation-mq"><script type="text/javascript" charset="UTF-8" src="./PLCB Public Meetings_files/element_main.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/mquery.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/core.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/dragdrop.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/callout.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/sharing.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/ScriptResx.ashx"></script><script type="text/javascript" src="./PLCB Public Meetings_files/sp.init.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/sp.ui.dialog.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/sp.runtime.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/sp.js"></script><script type="text/javascript" src="./PLCB Public Meetings_files/inplview.js"></script></head>
+<body onhashchange="if (typeof(_spBodyOnHashChange) != &#39;undefined&#39;) _spBodyOnHashChange();" style="position: relative; min-height: 100%; top: 0px;" class=" ms-backgroundImage"><form method="post" action="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx" onsubmit="javascript:return WebForm_OnSubmit();" id="aspnetForm">
 <div class="aspNetHidden">
-<input type="hidden" name="_wpcmWpid" id="_wpcmWpid" value="" />
-<input type="hidden" name="wpcmVal" id="wpcmVal" value="" />
-<input type="hidden" name="MSOWebPartPage_PostbackSource" id="MSOWebPartPage_PostbackSource" value="" />
-<input type="hidden" name="MSOTlPn_SelectedWpId" id="MSOTlPn_SelectedWpId" value="" />
-<input type="hidden" name="MSOTlPn_View" id="MSOTlPn_View" value="0" />
-<input type="hidden" name="MSOTlPn_ShowSettings" id="MSOTlPn_ShowSettings" value="False" />
-<input type="hidden" name="MSOGallery_SelectedLibrary" id="MSOGallery_SelectedLibrary" value="" />
-<input type="hidden" name="MSOGallery_FilterString" id="MSOGallery_FilterString" value="" />
-<input type="hidden" name="MSOTlPn_Button" id="MSOTlPn_Button" value="none" />
-<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
-<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
-<input type="hidden" name="__REQUESTDIGEST" id="__REQUESTDIGEST" value="0x3354DAA0D56CA9FD67408DE8908C12269A1C893A427FBBE75BC6354BF13D2F9E9AF49DC538643D0304A5C0AA491C16E34AC7E922E3DEEC2CF44B5587680D2833,09 Feb 2019 01:02:39 -0000" />
-<input type="hidden" name="MSOSPWebPartManager_DisplayModeName" id="MSOSPWebPartManager_DisplayModeName" value="Browse" />
-<input type="hidden" name="MSOSPWebPartManager_ExitingDesignMode" id="MSOSPWebPartManager_ExitingDesignMode" value="false" />
-<input type="hidden" name="MSOWebPartPage_Shared" id="MSOWebPartPage_Shared" value="" />
-<input type="hidden" name="MSOLayout_LayoutChanges" id="MSOLayout_LayoutChanges" value="" />
-<input type="hidden" name="MSOLayout_InDesignMode" id="MSOLayout_InDesignMode" value="" />
-<input type="hidden" name="_wpSelected" id="_wpSelected" value="" />
-<input type="hidden" name="_wzSelected" id="_wzSelected" value="" />
-<input type="hidden" name="MSOSPWebPartManager_OldDisplayModeName" id="MSOSPWebPartManager_OldDisplayModeName" value="Browse" />
-<input type="hidden" name="MSOSPWebPartManager_StartWebPartEditingName" id="MSOSPWebPartManager_StartWebPartEditingName" value="false" />
-<input type="hidden" name="MSOSPWebPartManager_EndWebPartEditing" id="MSOSPWebPartManager_EndWebPartEditing" value="false" />
-<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUBMA9kFgJmD2QWAgIBD2QWBgIBD2QWBAIPD2QWAmYPZBYCAgEPFgIeE1ByZXZpb3VzQ29udHJvbE1vZGULKYgBTWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViQ29udHJvbHMuU1BDb250cm9sTW9kZSwgTWljcm9zb2Z0LlNoYXJlUG9pbnQsIFZlcnNpb249MTUuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49NzFlOWJjZTExMWU5NDI5YwFkAhoPZBYCAgMPZBYCZg9kFgJmDzwrAAYAZAIDD2QWBAIJD2QWCAUmZ19hNzUyODQ0NV80YmJkXzQ2YTBfOTA0Yl9kMjdkZDNmOTY5OWIPZBYEZg8WAh4HVmlzaWJsZWhkAgEPFgIfAWhkBSZnX2IzODVlNWIwXzQ4Y2JfNDk4MV9hNDM3XzFhN2E5NzU1ZmFlYRAPFgYeC1BhcmFtVmFsdWVzMrEIAAEAAAD/////AQAAAAAAAAAMAgAAAFhNaWNyb3NvZnQuU2hhcmVQb2ludCwgVmVyc2lvbj0xNS4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj03MWU5YmNlMTExZTk0MjljBQEAAAA9TWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViUGFydFBhZ2VzLlBhcmFtZXRlck5hbWVWYWx1ZUhhc2h0YWJsZQEAAAAFX2NvbGwDHFN5c3RlbS5Db2xsZWN0aW9ucy5IYXNodGFibGUCAAAACQMAAAAEAwAAABxTeXN0ZW0uQ29sbGVjdGlvbnMuSGFzaHRhYmxlBwAAAApMb2FkRmFjdG9yB1ZlcnNpb24IQ29tcGFyZXIQSGFzaENvZGVQcm92aWRlcghIYXNoU2l6ZQRLZXlzBlZhbHVlcwAAAwMABQULCBxTeXN0ZW0uQ29sbGVjdGlvbnMuSUNvbXBhcmVyJFN5c3RlbS5Db2xsZWN0aW9ucy5JSGFzaENvZGVQcm92aWRlcgjsUTg/DAAAAAoKEQAAAAkEAAAACQUAAAAQBAAAAAoAAAAGBgAAAA9Ob0Fubm91bmNlbWVudHMGBwAAAApGaWx0ZXJMaW5rBggAAAANaWRQcmVzRW5hYmxlZAYJAAAACW9wZW5fbWVudQYKAAAAClNlbGVjdGVkSUQGCwAAABBkdnRfcHJldnBhZ2VkYXRhBgwAAAARZHZ0X3N0YXJ0cG9zaXRpb24GDQAAABVPcGVuTWVudUtleUFjY2Vzc2libGUGDgAAABNzZWxlY3RfZGVzZWxlY3RfYWxsBg8AAAAUTm9Bbm5vdW5jZW1lbnRzSG93VG8QBQAAAAoAAAAGEAAAAHFUaGVyZSBhcmUgbm8gaXRlbXMgdG8gc2hvdyBpbiB0aGlzIHZpZXcgb2YgdGhlICJDdXJyZW50IFllYXIgQm9hcmQgQWdlbmRhcyBhbmQgTWVldGluZyBNaW51dGVzIiBkb2N1bWVudCBsaWJyYXJ5LgYRAAAAAT8GEgAAACBQcmVzZW5jZSBlbmFibGVkIGZvciB0aGlzIGNvbHVtbgYTAAAACU9wZW4gTWVudQYUAAAAAi0xBhUAAABPUGFnZWQ9VFJVRSZQYWdlZFByZXY9VFJVRSZwX1NvcnRCZWhhdmlvcj0wJnBfT3JkZXIwPTIlMmUwMDAwMDAwMDAwMDAwMCZwX0lEPTEyMAYWAAAAAAYXAAAALlVzZSBTSElGVCtFTlRFUiB0byBvcGVuIHRoZSBtZW51IChuZXcgd2luZG93KS4GGAAAABxTZWxlY3Qgb3IgZGVzZWxlY3QgYWxsIGl0ZW1zBhkAAAArVG8gYWRkIGEgbmV3IGl0ZW0sIGNsaWNrICJOZXciIG9yICJVcGxvYWQiLgseEEZpbHRlck9wZXJhdGlvbnMyjQUAAQAAAP////8BAAAAAAAAAAQBAAAAkwJTeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5EaWN0aW9uYXJ5YDJbW1N5c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV0sW01pY3Jvc29mdC5TaGFyZVBvaW50LldlYlBhcnRQYWdlcy5GaWx0ZXJPcGVyYXRpb24sIE1pY3Jvc29mdC5TaGFyZVBvaW50LCBWZXJzaW9uPTE1LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTcxZTliY2UxMTFlOTQyOWNdXQMAAAAHVmVyc2lvbghDb21wYXJlcghIYXNoU2l6ZQADAAiSAVN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkdlbmVyaWNFcXVhbGl0eUNvbXBhcmVyYDFbW1N5c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV1dCAAAAAAJAgAAAAAAAAAEAgAAAJIBU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuR2VuZXJpY0VxdWFsaXR5Q29tcGFyZXJgMVtbU3lzdGVtLlN0cmluZywgbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0AAAAACx4MX3ZpZXdDb3VudGVyAiJkZGQFJmdfODY0ZThmODdfNGMyM180NGU5X2EwNTFfN2M4MzhhMjY1NGFiEA8WBh8CMqMIAAEAAAD/////AQAAAAAAAAAMAgAAAFhNaWNyb3NvZnQuU2hhcmVQb2ludCwgVmVyc2lvbj0xNS4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj03MWU5YmNlMTExZTk0MjljBQEAAAA9TWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViUGFydFBhZ2VzLlBhcmFtZXRlck5hbWVWYWx1ZUhhc2h0YWJsZQEAAAAFX2NvbGwDHFN5c3RlbS5Db2xsZWN0aW9ucy5IYXNodGFibGUCAAAACQMAAAAEAwAAABxTeXN0ZW0uQ29sbGVjdGlvbnMuSGFzaHRhYmxlBwAAAApMb2FkRmFjdG9yB1ZlcnNpb24IQ29tcGFyZXIQSGFzaENvZGVQcm92aWRlcghIYXNoU2l6ZQRLZXlzBlZhbHVlcwAAAwMABQULCBxTeXN0ZW0uQ29sbGVjdGlvbnMuSUNvbXBhcmVyJFN5c3RlbS5Db2xsZWN0aW9ucy5JSGFzaENvZGVQcm92aWRlcgjsUTg/DAAAAAoKEQAAAAkEAAAACQUAAAAQBAAAAAoAAAAGBgAAAA9Ob0Fubm91bmNlbWVudHMGBwAAAApGaWx0ZXJMaW5rBggAAAANaWRQcmVzRW5hYmxlZAYJAAAACW9wZW5fbWVudQYKAAAAClNlbGVjdGVkSUQGCwAAABBkdnRfcHJldnBhZ2VkYXRhBgwAAAARZHZ0X3N0YXJ0cG9zaXRpb24GDQAAABVPcGVuTWVudUtleUFjY2Vzc2libGUGDgAAABNzZWxlY3RfZGVzZWxlY3RfYWxsBg8AAAAUTm9Bbm5vdW5jZW1lbnRzSG93VG8QBQAAAAoAAAAGEAAAAFdUaGVyZSBhcmUgbm8gaXRlbXMgdG8gc2hvdyBpbiB0aGlzIHZpZXcgb2YgdGhlICIyMDE3IE1lZXRpbmcgTWludXRlcyIgZG9jdW1lbnQgbGlicmFyeS4GEQAAAAE/BhIAAAAgUHJlc2VuY2UgZW5hYmxlZCBmb3IgdGhpcyBjb2x1bW4GEwAAAAlPcGVuIE1lbnUGFAAAAAItMQYVAAAAW1BhZ2VkPVRSVUUmUGFnZWRQcmV2PVRSVUUmcF9Tb3J0QmVoYXZpb3I9MCZwX0ZpbGVMZWFmUmVmPUFwcmlsJTIwMTklMmMlMjAyMDE3JTJlcGRmJnBfSUQ9OTYGFgAAAAAGFwAAAC5Vc2UgU0hJRlQrRU5URVIgdG8gb3BlbiB0aGUgbWVudSAobmV3IHdpbmRvdykuBhgAAAAcU2VsZWN0IG9yIGRlc2VsZWN0IGFsbCBpdGVtcwYZAAAAK1RvIGFkZCBhIG5ldyBpdGVtLCBjbGljayAiTmV3IiBvciAiVXBsb2FkIi4LHwMyjQUAAQAAAP////8BAAAAAAAAAAQBAAAAkwJTeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5EaWN0aW9uYXJ5YDJbW1N5c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV0sW01pY3Jvc29mdC5TaGFyZVBvaW50LldlYlBhcnRQYWdlcy5GaWx0ZXJPcGVyYXRpb24sIE1pY3Jvc29mdC5TaGFyZVBvaW50LCBWZXJzaW9uPTE1LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTcxZTliY2UxMTFlOTQyOWNdXQMAAAAHVmVyc2lvbghDb21wYXJlcghIYXNoU2l6ZQADAAiSAVN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkdlbmVyaWNFcXVhbGl0eUNvbXBhcmVyYDFbW1N5c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV1dCAAAAAAJAgAAAAAAAAAEAgAAAJIBU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuR2VuZXJpY0VxdWFsaXR5Q29tcGFyZXJgMVtbU3lzdGVtLlN0cmluZywgbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0AAAAACx8EAiNkZGQFJmdfN2Q5NjFkMGZfZWJlYV80NTgzX2I4YjZfODAzMTkwNzc4YTY4EA8WBh8CMqMIAAEAAAD/////AQAAAAAAAAAMAgAAAFhNaWNyb3NvZnQuU2hhcmVQb2ludCwgVmVyc2lvbj0xNS4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj03MWU5YmNlMTExZTk0MjljBQEAAAA9TWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViUGFydFBhZ2VzLlBhcmFtZXRlck5hbWVWYWx1ZUhhc2h0YWJsZQEAAAAFX2NvbGwDHFN5c3RlbS5Db2xsZWN0aW9ucy5IYXNodGFibGUCAAAACQMAAAAEAwAAABxTeXN0ZW0uQ29sbGVjdGlvbnMuSGFzaHRhYmxlBwAAAApMb2FkRmFjdG9yB1ZlcnNpb24IQ29tcGFyZXIQSGFzaENvZGVQcm92aWRlcghIYXNoU2l6ZQRLZXlzBlZhbHVlcwAAAwMABQULCBxTeXN0ZW0uQ29sbGVjdGlvbnMuSUNvbXBhcmVyJFN5c3RlbS5Db2xsZWN0aW9ucy5JSGFzaENvZGVQcm92aWRlcgjsUTg/DAAAAAoKEQAAAAkEAAAACQUAAAAQBAAAAAoAAAAGBgAAAA9Ob0Fubm91bmNlbWVudHMGBwAAAApGaWx0ZXJMaW5rBggAAAANaWRQcmVzRW5hYmxlZAYJAAAACW9wZW5fbWVudQYKAAAAClNlbGVjdGVkSUQGCwAAABBkdnRfcHJldnBhZ2VkYXRhBgwAAAARZHZ0X3N0YXJ0cG9zaXRpb24GDQAAABVPcGVuTWVudUtleUFjY2Vzc2libGUGDgAAABNzZWxlY3RfZGVzZWxlY3RfYWxsBg8AAAAUTm9Bbm5vdW5jZW1lbnRzSG93VG8QBQAAAAoAAAAGEAAAAFdUaGVyZSBhcmUgbm8gaXRlbXMgdG8gc2hvdyBpbiB0aGlzIHZpZXcgb2YgdGhlICIyMDE3IE1lZXRpbmcgTWludXRlcyIgZG9jdW1lbnQgbGlicmFyeS4GEQAAAAE/BhIAAAAgUHJlc2VuY2UgZW5hYmxlZCBmb3IgdGhpcyBjb2x1bW4GEwAAAAlPcGVuIE1lbnUGFAAAAAItMQYVAAAAW1BhZ2VkPVRSVUUmUGFnZWRQcmV2PVRSVUUmcF9Tb3J0QmVoYXZpb3I9MCZwX0ZpbGVMZWFmUmVmPUFwcmlsJTIwMTklMmMlMjAyMDE3JTJlcGRmJnBfSUQ9OTYGFgAAAAAGFwAAAC5Vc2UgU0hJRlQrRU5URVIgdG8gb3BlbiB0aGUgbWVudSAobmV3IHdpbmRvdykuBhgAAAAcU2VsZWN0IG9yIGRlc2VsZWN0IGFsbCBpdGVtcwYZAAAAK1RvIGFkZCBhIG5ldyBpdGVtLCBjbGljayAiTmV3IiBvciAiVXBsb2FkIi4LHwMyjQUAAQAAAP////8BAAAAAAAAAAQBAAAAkwJTeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5EaWN0aW9uYXJ5YDJbW1N5c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV0sW01pY3Jvc29mdC5TaGFyZVBvaW50LldlYlBhcnRQYWdlcy5GaWx0ZXJPcGVyYXRpb24sIE1pY3Jvc29mdC5TaGFyZVBvaW50LCBWZXJzaW9uPTE1LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTcxZTliY2UxMTFlOTQyOWNdXQMAAAAHVmVyc2lvbghDb21wYXJlcghIYXNoU2l6ZQADAAiSAVN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkdlbmVyaWNFcXVhbGl0eUNvbXBhcmVyYDFbW1N5c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV1dCAAAAAAJAgAAAAAAAAAEAgAAAJIBU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuR2VuZXJpY0VxdWFsaXR5Q29tcGFyZXJgMVtbU3lzdGVtLlN0cmluZywgbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0AAAAACx8EAiRkZGQCEQ9kFgQCAQ9kFgICAg9kFgICBQ9kFgICAw8WAh8BaBYCZg9kFgQCAg9kFgYCAQ8WAh8BaGQCAw8WAh8BaGQCBQ8WAh8BaGQCAw8PFgIeCUFjY2Vzc0tleQUBL2RkAg0PZBYCAgIPZBYCAgMPFgIfAAsrBAFkAgwPZBYCAgEPFgIfAAsrBAFkZAALTdltre90LwA07KOkS0eaQ0Fb80hIxm/T2A5HCD0S" />
+<input type="hidden" name="_wpcmWpid" id="_wpcmWpid" value="">
+<input type="hidden" name="wpcmVal" id="wpcmVal" value="">
+<input type="hidden" name="MSOWebPartPage_PostbackSource" id="MSOWebPartPage_PostbackSource" value="">
+<input type="hidden" name="MSOTlPn_SelectedWpId" id="MSOTlPn_SelectedWpId" value="">
+<input type="hidden" name="MSOTlPn_View" id="MSOTlPn_View" value="0">
+<input type="hidden" name="MSOTlPn_ShowSettings" id="MSOTlPn_ShowSettings" value="False">
+<input type="hidden" name="MSOGallery_SelectedLibrary" id="MSOGallery_SelectedLibrary" value="">
+<input type="hidden" name="MSOGallery_FilterString" id="MSOGallery_FilterString" value="">
+<input type="hidden" name="MSOTlPn_Button" id="MSOTlPn_Button" value="none">
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="">
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="">
+<input type="hidden" name="__REQUESTDIGEST" id="__REQUESTDIGEST" value="0xE93D5FB5CD4D8E0E8FFDF1F649E7527BE2DADCBC2676DD1CC9F6EBD359CD901D10DC2BD1DC29EE0C83F6258A641E880415CDEC7C2BECF56A956016FB4C3CB598,02 Feb 2020 03:49:38 -0000">
+<input type="hidden" name="MSOSPWebPartManager_DisplayModeName" id="MSOSPWebPartManager_DisplayModeName" value="Browse">
+<input type="hidden" name="MSOSPWebPartManager_ExitingDesignMode" id="MSOSPWebPartManager_ExitingDesignMode" value="false">
+<input type="hidden" name="MSOWebPartPage_Shared" id="MSOWebPartPage_Shared" value="">
+<input type="hidden" name="MSOLayout_LayoutChanges" id="MSOLayout_LayoutChanges" value="">
+<input type="hidden" name="MSOLayout_InDesignMode" id="MSOLayout_InDesignMode" value="">
+<input type="hidden" name="_wpSelected" id="_wpSelected" value="">
+<input type="hidden" name="_wzSelected" id="_wzSelected" value="">
+<input type="hidden" name="MSOSPWebPartManager_OldDisplayModeName" id="MSOSPWebPartManager_OldDisplayModeName" value="Browse">
+<input type="hidden" name="MSOSPWebPartManager_StartWebPartEditingName" id="MSOSPWebPartManager_StartWebPartEditingName" value="false">
+<input type="hidden" name="MSOSPWebPartManager_EndWebPartEditing" id="MSOSPWebPartManager_EndWebPartEditing" value="false">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUBMA9kFgJmD2QWAgIBD2QWBgIBD2QWBAIPD2QWAmYPZBYCAgEPFgIeE1ByZXZpb3VzQ29udHJvbE1vZGULKYgBTWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViQ29udHJvbHMuU1BDb250cm9sTW9kZSwgTWljcm9zb2Z0LlNoYXJlUG9pbnQsIFZlcnNpb249MTUuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49NzFlOWJjZTExMWU5NDI5YwFkAhoPZBYCAgMPZBYCZg9kFgJmDzwrAAYAZAIDD2QWBAIJD2QWCAUmZ19hNzUyODQ0NV80YmJkXzQ2YTBfOTA0Yl9kMjdkZDNmOTY5OWIPZBYEZg8WAh4HVmlzaWJsZWhkAgEPFgIfAWhkBSZnXzg2NGU4Zjg3XzRjMjNfNDRlOV9hMDUxXzdjODM4YTI2NTRhYhAPFgYeC1BhcmFtVmFsdWVzMqMIAAEAAAD/////AQAAAAAAAAAMAgAAAFhNaWNyb3NvZnQuU2hhcmVQb2ludCwgVmVyc2lvbj0xNS4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj03MWU5YmNlMTExZTk0MjljBQEAAAA9TWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViUGFydFBhZ2VzLlBhcmFtZXRlck5hbWVWYWx1ZUhhc2h0YWJsZQEAAAAFX2NvbGwDHFN5c3RlbS5Db2xsZWN0aW9ucy5IYXNodGFibGUCAAAACQMAAAAEAwAAABxTeXN0ZW0uQ29sbGVjdGlvbnMuSGFzaHRhYmxlBwAAAApMb2FkRmFjdG9yB1ZlcnNpb24IQ29tcGFyZXIQSGFzaENvZGVQcm92aWRlcghIYXNoU2l6ZQRLZXlzBlZhbHVlcwAAAwMABQULCBxTeXN0ZW0uQ29sbGVjdGlvbnMuSUNvbXBhcmVyJFN5c3RlbS5Db2xsZWN0aW9ucy5JSGFzaENvZGVQcm92aWRlcgjsUTg/DAAAAAoKEQAAAAkEAAAACQUAAAAQBAAAAAoAAAAGBgAAAA9Ob0Fubm91bmNlbWVudHMGBwAAAApGaWx0ZXJMaW5rBggAAAANaWRQcmVzRW5hYmxlZAYJAAAACW9wZW5fbWVudQYKAAAAClNlbGVjdGVkSUQGCwAAABBkdnRfcHJldnBhZ2VkYXRhBgwAAAARZHZ0X3N0YXJ0cG9zaXRpb24GDQAAABVPcGVuTWVudUtleUFjY2Vzc2libGUGDgAAABNzZWxlY3RfZGVzZWxlY3RfYWxsBg8AAAAUTm9Bbm5vdW5jZW1lbnRzSG93VG8QBQAAAAoAAAAGEAAAAFdUaGVyZSBhcmUgbm8gaXRlbXMgdG8gc2hvdyBpbiB0aGlzIHZpZXcgb2YgdGhlICIyMDE3IE1lZXRpbmcgTWludXRlcyIgZG9jdW1lbnQgbGlicmFyeS4GEQAAAAE/BhIAAAAgUHJlc2VuY2UgZW5hYmxlZCBmb3IgdGhpcyBjb2x1bW4GEwAAAAlPcGVuIE1lbnUGFAAAAAItMQYVAAAAW1BhZ2VkPVRSVUUmUGFnZWRQcmV2PVRSVUUmcF9Tb3J0QmVoYXZpb3I9MCZwX0ZpbGVMZWFmUmVmPUFwcmlsJTIwMTklMmMlMjAyMDE3JTJlcGRmJnBfSUQ9OTYGFgAAAAAGFwAAAC5Vc2UgU0hJRlQrRU5URVIgdG8gb3BlbiB0aGUgbWVudSAobmV3IHdpbmRvdykuBhgAAAAcU2VsZWN0IG9yIGRlc2VsZWN0IGFsbCBpdGVtcwYZAAAAK1RvIGFkZCBhIG5ldyBpdGVtLCBjbGljayAiTmV3IiBvciAiVXBsb2FkIi4LHhBGaWx0ZXJPcGVyYXRpb25zMo0FAAEAAAD/////AQAAAAAAAAAEAQAAAJMCU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuRGljdGlvbmFyeWAyW1tTeXN0ZW0uU3RyaW5nLCBtc2NvcmxpYiwgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODldLFtNaWNyb3NvZnQuU2hhcmVQb2ludC5XZWJQYXJ0UGFnZXMuRmlsdGVyT3BlcmF0aW9uLCBNaWNyb3NvZnQuU2hhcmVQb2ludCwgVmVyc2lvbj0xNS4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj03MWU5YmNlMTExZTk0MjljXV0DAAAAB1ZlcnNpb24IQ29tcGFyZXIISGFzaFNpemUAAwAIkgFTeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5HZW5lcmljRXF1YWxpdHlDb21wYXJlcmAxW1tTeXN0ZW0uU3RyaW5nLCBtc2NvcmxpYiwgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODldXQgAAAAACQIAAAAAAAAABAIAAACSAVN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkdlbmVyaWNFcXVhbGl0eUNvbXBhcmVyYDFbW1N5c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV1dAAAAAAseDF92aWV3Q291bnRlcgKrA2RkZAUmZ183ZDk2MWQwZl9lYmVhXzQ1ODNfYjhiNl84MDMxOTA3NzhhNjgQDxYGHwIyowgAAQAAAP////8BAAAAAAAAAAwCAAAAWE1pY3Jvc29mdC5TaGFyZVBvaW50LCBWZXJzaW9uPTE1LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTcxZTliY2UxMTFlOTQyOWMFAQAAAD1NaWNyb3NvZnQuU2hhcmVQb2ludC5XZWJQYXJ0UGFnZXMuUGFyYW1ldGVyTmFtZVZhbHVlSGFzaHRhYmxlAQAAAAVfY29sbAMcU3lzdGVtLkNvbGxlY3Rpb25zLkhhc2h0YWJsZQIAAAAJAwAAAAQDAAAAHFN5c3RlbS5Db2xsZWN0aW9ucy5IYXNodGFibGUHAAAACkxvYWRGYWN0b3IHVmVyc2lvbghDb21wYXJlchBIYXNoQ29kZVByb3ZpZGVyCEhhc2hTaXplBEtleXMGVmFsdWVzAAADAwAFBQsIHFN5c3RlbS5Db2xsZWN0aW9ucy5JQ29tcGFyZXIkU3lzdGVtLkNvbGxlY3Rpb25zLklIYXNoQ29kZVByb3ZpZGVyCOxROD8MAAAACgoRAAAACQQAAAAJBQAAABAEAAAACgAAAAYGAAAAD05vQW5ub3VuY2VtZW50cwYHAAAACkZpbHRlckxpbmsGCAAAAA1pZFByZXNFbmFibGVkBgkAAAAJb3Blbl9tZW51BgoAAAAKU2VsZWN0ZWRJRAYLAAAAEGR2dF9wcmV2cGFnZWRhdGEGDAAAABFkdnRfc3RhcnRwb3NpdGlvbgYNAAAAFU9wZW5NZW51S2V5QWNjZXNzaWJsZQYOAAAAE3NlbGVjdF9kZXNlbGVjdF9hbGwGDwAAABROb0Fubm91bmNlbWVudHNIb3dUbxAFAAAACgAAAAYQAAAAV1RoZXJlIGFyZSBubyBpdGVtcyB0byBzaG93IGluIHRoaXMgdmlldyBvZiB0aGUgIjIwMTcgTWVldGluZyBNaW51dGVzIiBkb2N1bWVudCBsaWJyYXJ5LgYRAAAAAT8GEgAAACBQcmVzZW5jZSBlbmFibGVkIGZvciB0aGlzIGNvbHVtbgYTAAAACU9wZW4gTWVudQYUAAAAAi0xBhUAAABbUGFnZWQ9VFJVRSZQYWdlZFByZXY9VFJVRSZwX1NvcnRCZWhhdmlvcj0wJnBfRmlsZUxlYWZSZWY9QXByaWwlMjAxOSUyYyUyMDIwMTclMmVwZGYmcF9JRD05NgYWAAAAAAYXAAAALlVzZSBTSElGVCtFTlRFUiB0byBvcGVuIHRoZSBtZW51IChuZXcgd2luZG93KS4GGAAAABxTZWxlY3Qgb3IgZGVzZWxlY3QgYWxsIGl0ZW1zBhkAAAArVG8gYWRkIGEgbmV3IGl0ZW0sIGNsaWNrICJOZXciIG9yICJVcGxvYWQiLgsfAzKNBQABAAAA/////wEAAAAAAAAABAEAAACTAlN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkRpY3Rpb25hcnlgMltbU3lzdGVtLlN0cmluZywgbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XSxbTWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViUGFydFBhZ2VzLkZpbHRlck9wZXJhdGlvbiwgTWljcm9zb2Z0LlNoYXJlUG9pbnQsIFZlcnNpb249MTUuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49NzFlOWJjZTExMWU5NDI5Y11dAwAAAAdWZXJzaW9uCENvbXBhcmVyCEhhc2hTaXplAAMACJIBU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuR2VuZXJpY0VxdWFsaXR5Q29tcGFyZXJgMVtbU3lzdGVtLlN0cmluZywgbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0IAAAAAAkCAAAAAAAAAAQCAAAAkgFTeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5HZW5lcmljRXF1YWxpdHlDb21wYXJlcmAxW1tTeXN0ZW0uU3RyaW5nLCBtc2NvcmxpYiwgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODldXQAAAAALHwQCrANkZGQFJmdfYjM4NWU1YjBfNDhjYl80OTgxX2E0MzdfMWE3YTk3NTVmYWVhEA8WBh8CMrEIAAEAAAD/////AQAAAAAAAAAMAgAAAFhNaWNyb3NvZnQuU2hhcmVQb2ludCwgVmVyc2lvbj0xNS4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj03MWU5YmNlMTExZTk0MjljBQEAAAA9TWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViUGFydFBhZ2VzLlBhcmFtZXRlck5hbWVWYWx1ZUhhc2h0YWJsZQEAAAAFX2NvbGwDHFN5c3RlbS5Db2xsZWN0aW9ucy5IYXNodGFibGUCAAAACQMAAAAEAwAAABxTeXN0ZW0uQ29sbGVjdGlvbnMuSGFzaHRhYmxlBwAAAApMb2FkRmFjdG9yB1ZlcnNpb24IQ29tcGFyZXIQSGFzaENvZGVQcm92aWRlcghIYXNoU2l6ZQRLZXlzBlZhbHVlcwAAAwMABQULCBxTeXN0ZW0uQ29sbGVjdGlvbnMuSUNvbXBhcmVyJFN5c3RlbS5Db2xsZWN0aW9ucy5JSGFzaENvZGVQcm92aWRlcgjsUTg/DAAAAAoKEQAAAAkEAAAACQUAAAAQBAAAAAoAAAAGBgAAAA9Ob0Fubm91bmNlbWVudHMGBwAAAApGaWx0ZXJMaW5rBggAAAANaWRQcmVzRW5hYmxlZAYJAAAACW9wZW5fbWVudQYKAAAAClNlbGVjdGVkSUQGCwAAABBkdnRfcHJldnBhZ2VkYXRhBgwAAAARZHZ0X3N0YXJ0cG9zaXRpb24GDQAAABVPcGVuTWVudUtleUFjY2Vzc2libGUGDgAAABNzZWxlY3RfZGVzZWxlY3RfYWxsBg8AAAAUTm9Bbm5vdW5jZW1lbnRzSG93VG8QBQAAAAoAAAAGEAAAAHFUaGVyZSBhcmUgbm8gaXRlbXMgdG8gc2hvdyBpbiB0aGlzIHZpZXcgb2YgdGhlICJDdXJyZW50IFllYXIgQm9hcmQgQWdlbmRhcyBhbmQgTWVldGluZyBNaW51dGVzIiBkb2N1bWVudCBsaWJyYXJ5LgYRAAAAAT8GEgAAACBQcmVzZW5jZSBlbmFibGVkIGZvciB0aGlzIGNvbHVtbgYTAAAACU9wZW4gTWVudQYUAAAAAi0xBhUAAABPUGFnZWQ9VFJVRSZQYWdlZFByZXY9VFJVRSZwX1NvcnRCZWhhdmlvcj0wJnBfT3JkZXIwPTIlMmUwMDAwMDAwMDAwMDAwMCZwX0lEPTE0OAYWAAAAAAYXAAAALlVzZSBTSElGVCtFTlRFUiB0byBvcGVuIHRoZSBtZW51IChuZXcgd2luZG93KS4GGAAAABxTZWxlY3Qgb3IgZGVzZWxlY3QgYWxsIGl0ZW1zBhkAAAArVG8gYWRkIGEgbmV3IGl0ZW0sIGNsaWNrICJOZXciIG9yICJVcGxvYWQiLgsfAzKNBQABAAAA/////wEAAAAAAAAABAEAAACTAlN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkRpY3Rpb25hcnlgMltbU3lzdGVtLlN0cmluZywgbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XSxbTWljcm9zb2Z0LlNoYXJlUG9pbnQuV2ViUGFydFBhZ2VzLkZpbHRlck9wZXJhdGlvbiwgTWljcm9zb2Z0LlNoYXJlUG9pbnQsIFZlcnNpb249MTUuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49NzFlOWJjZTExMWU5NDI5Y11dAwAAAAdWZXJzaW9uCENvbXBhcmVyCEhhc2hTaXplAAMACJIBU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuR2VuZXJpY0VxdWFsaXR5Q29tcGFyZXJgMVtbU3lzdGVtLlN0cmluZywgbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0IAAAAAAkCAAAAAAAAAAQCAAAAkgFTeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5HZW5lcmljRXF1YWxpdHlDb21wYXJlcmAxW1tTeXN0ZW0uU3RyaW5nLCBtc2NvcmxpYiwgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODldXQAAAAALHwQCrQNkZGQCEQ9kFgQCAQ9kFgICAg9kFgICBQ9kFgICAw8WAh8BaBYCZg9kFgQCAg9kFgYCAQ8WAh8BaGQCAw8WAh8BaGQCBQ8WAh8BaGQCAw8PFgIeCUFjY2Vzc0tleQUBL2RkAg0PZBYCAgIPZBYCAgMPFgIfAAsrBAFkAgwPZBYCAgEPFgIfAAsrBAFkZNl57byiERv4e6eQHxjfBJ1xJDo/HKgb9d6Eo/aG1HR3">
 </div>
 
 <script type="text/javascript">
@@ -176,7 +175,7 @@ function __doPostBack(eventTarget, eventArgument) {
 </script>
 
 
-<script src="/WebResource.axd?d=rlFLBXf5A5TbWxy1q0az4zOQcli5mD3GA5HStSgMfDsqVLaxZWjlcJHcWboATJftgn-O88E63DsvUnkNNVHyEO-OXDOgUJUSkQ6G7_3lLX41&amp;t=636765319264470882" type="text/javascript"></script>
+<script src="./PLCB Public Meetings_files/WebResource.axd" type="text/javascript"></script>
 
 
 <script type="text/javascript">
@@ -189,13 +188,13 @@ var g_wsaQoSDataPoints = [];
 var g_wsaLCID = 1033;
 var g_wsaListTemplateId = 850;
 var g_wsaSiteTemplateId = 'CMSPUBLISHING#0';
-var _fV4UI=true;var _spPageContextInfo = {webServerRelativeUrl: "\u002fAbout-Us\u002fBoard", webAbsoluteUrl: "https:\u002f\u002fwww.lcb.pa.gov\u002fAbout-Us\u002fBoard", siteAbsoluteUrl: "https:\u002f\u002fwww.lcb.pa.gov", serverRequestPath: "\u002fAbout-Us\u002fBoard\u002fPages\u002fPublic-Meetings.aspx", layoutsUrl: "_layouts\u002f15", webTitle: "Board", webTemplate: "39", tenantAppVersion: "0", isAppWeb: false, webLogoUrl: "_layouts\u002f15\u002fimages\u002fsiteicon.png", webLanguage: 1033, currentLanguage: 1033, currentUICultureName: "en-US", currentCultureName: "en-US", clientServerTimeDelta: new Date("2019-02-09T01:02:39.6980727Z") - new Date(), siteClientTag: "215$$15.0.5093.1000", crossDomainPhotosEnabled:false, webUIVersion:15, webPermMasks:{High:16,Low:196673},pageListId:"{fcb04add-3188-47aa-a961-12029f49f687}",pageItemId:3, pagePersonalizationScope:1, alertsEnabled:true, siteServerRelativeUrl: "\u002f", allowSilverlightPrompt:'True'};var L_Menu_BaseUrl="/About-Us/Board";
+var _fV4UI=true;var _spPageContextInfo = {webServerRelativeUrl: "\u002fAbout-Us\u002fBoard", webAbsoluteUrl: "https:\u002f\u002fwww.lcb.pa.gov\u002fAbout-Us\u002fBoard", siteAbsoluteUrl: "https:\u002f\u002fwww.lcb.pa.gov", serverRequestPath: "\u002fAbout-Us\u002fBoard\u002fPages\u002fPublic-Meetings.aspx", layoutsUrl: "_layouts\u002f15", webTitle: "Board", webTemplate: "39", tenantAppVersion: "0", isAppWeb: false, Has2019Era: true, webLogoUrl: "_layouts\u002f15\u002fimages\u002fsiteicon.png", webLanguage: 1033, currentLanguage: 1033, currentUICultureName: "en-US", currentCultureName: "en-US", clientServerTimeDelta: new Date("2020-02-02T03:49:37.7201900Z") - new Date(), siteClientTag: "1532$$15.0.5207.1000", crossDomainPhotosEnabled:false, webUIVersion:15, webPermMasks:{High:16,Low:196673},pageListId:"{fcb04add-3188-47aa-a961-12029f49f687}",pageItemId:3, pagePersonalizationScope:1, alertsEnabled:true, siteServerRelativeUrl: "\u002f", allowSilverlightPrompt:'True'};var L_Menu_BaseUrl="/About-Us/Board";
 var L_Menu_LCID="1033";
 var L_Menu_SiteTheme="null";
-document.onreadystatechange=fnRemoveAllStatus; function fnRemoveAllStatus(){removeAllStatus(true)};var _spWebPartComponents = new Object();_spWebPartComponents["WebPartWPQ2"] = new Object();_spWebPartComponents["WebPartWPQ2"].firstTabId = "Ribbon.Read";_spWebPartComponents["WebPartWPQ2"].initPageComponentScript = "SP.Ribbon.WebPartComponent.fetchListViewWebPartPageComponent\u0028\u0027g_b385e5b0_48cb_4981_a437_1a7a9755faea\u0027, \u0027WebPartWPQ2\u0027, \u00273eebada2-e8ec-4af1-97f1-43643078072b\u0027, \u0027b2f22707-7334-4e25-8162-32199003bea3\u0027\u0029;";_spWebPartComponents["WebPartWPQ2"].contextualGroupCommands = ["LibraryContextualGroup"];_spWebPartComponents["WebPartWPQ2"].hasNonPromotedContextualGroups = true;_spWebPartComponents["WebPartWPQ2"].isDefaultWebPart = false;_spWebPartComponents["WebPartWPQ2"].pageComponentId = "WebPartWPQ2";_spWebPartComponents["WebPartWPQ2"].storageId="b2f22707-7334-4e25-8162-32199003bea3";_spWebPartComponents["WebPartWPQ3"] = new Object();_spWebPartComponents["WebPartWPQ3"].firstTabId = "Ribbon.Read";_spWebPartComponents["WebPartWPQ3"].contextualGroupCommands = ["LibraryContextualGroup"];_spWebPartComponents["WebPartWPQ3"].hasNonPromotedContextualGroups = true;_spWebPartComponents["WebPartWPQ3"].isDefaultWebPart = false;_spWebPartComponents["WebPartWPQ3"].pageComponentId = "WebPartWPQ3";_spWebPartComponents["WebPartWPQ3"].storageId="b1692d68-0638-405b-b4fd-3a8c40498e30";_spWebPartComponents["WebPartWPQ4"] = new Object();_spWebPartComponents["WebPartWPQ4"].firstTabId = "Ribbon.Read";_spWebPartComponents["WebPartWPQ4"].contextualGroupCommands = ["LibraryContextualGroup"];_spWebPartComponents["WebPartWPQ4"].hasNonPromotedContextualGroups = true;_spWebPartComponents["WebPartWPQ4"].isDefaultWebPart = false;_spWebPartComponents["WebPartWPQ4"].pageComponentId = "WebPartWPQ4";_spWebPartComponents["WebPartWPQ4"].storageId="6b982743-aceb-457f-96b7-d1e33da995eb";//]]>
+document.onreadystatechange=fnRemoveAllStatus; function fnRemoveAllStatus(){removeAllStatus(true)};var _spWebPartComponents = new Object();_spWebPartComponents["WebPartWPQ2"] = new Object();_spWebPartComponents["WebPartWPQ2"].firstTabId = "Ribbon.Read";_spWebPartComponents["WebPartWPQ2"].contextualGroupCommands = ["LibraryContextualGroup"];_spWebPartComponents["WebPartWPQ2"].hasNonPromotedContextualGroups = true;_spWebPartComponents["WebPartWPQ2"].isDefaultWebPart = false;_spWebPartComponents["WebPartWPQ2"].pageComponentId = "WebPartWPQ2";_spWebPartComponents["WebPartWPQ2"].storageId="b1692d68-0638-405b-b4fd-3a8c40498e30";_spWebPartComponents["WebPartWPQ3"] = new Object();_spWebPartComponents["WebPartWPQ3"].firstTabId = "Ribbon.Read";_spWebPartComponents["WebPartWPQ3"].contextualGroupCommands = ["LibraryContextualGroup"];_spWebPartComponents["WebPartWPQ3"].hasNonPromotedContextualGroups = true;_spWebPartComponents["WebPartWPQ3"].isDefaultWebPart = false;_spWebPartComponents["WebPartWPQ3"].pageComponentId = "WebPartWPQ3";_spWebPartComponents["WebPartWPQ3"].storageId="6b982743-aceb-457f-96b7-d1e33da995eb";_spWebPartComponents["WebPartWPQ4"] = new Object();_spWebPartComponents["WebPartWPQ4"].firstTabId = "Ribbon.Read";_spWebPartComponents["WebPartWPQ4"].initPageComponentScript = "SP.Ribbon.WebPartComponent.fetchListViewWebPartPageComponent\u0028\u0027g_b385e5b0_48cb_4981_a437_1a7a9755faea\u0027, \u0027WebPartWPQ4\u0027, \u00273eebada2-e8ec-4af1-97f1-43643078072b\u0027, \u0027b2f22707-7334-4e25-8162-32199003bea3\u0027\u0029;";_spWebPartComponents["WebPartWPQ4"].contextualGroupCommands = ["LibraryContextualGroup"];_spWebPartComponents["WebPartWPQ4"].hasNonPromotedContextualGroups = true;_spWebPartComponents["WebPartWPQ4"].isDefaultWebPart = false;_spWebPartComponents["WebPartWPQ4"].pageComponentId = "WebPartWPQ4";_spWebPartComponents["WebPartWPQ4"].storageId="b2f22707-7334-4e25-8162-32199003bea3";//]]>
 </script>
 
-<script src="/_layouts/15/blank.js?rev=ZaOXZEobVwykPO9g8hq%2F8A%3D%3D" type="text/javascript"></script>
+<script src="./PLCB Public Meetings_files/blank.js" type="text/javascript"></script>
 <script type="text/javascript">
 //<![CDATA[
            
@@ -304,14 +303,14 @@ return true;
 
 								<div class="aspNetHidden">
 
-									<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="CB5687A9" />
-									<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAIXkDXuGvBPXMysi9EXUKjDBQHXCMm5kphfWoVWItaLzRqvmgdDVQ7FBuHUvzMqfYiI5zgiVWHUqeS309f6NjEf" />
+									<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="CB5687A9">
+									<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAM1IWu5KxjBIPnu3kN/3GRNBQHXCMm5kphfWoVWItaLzacXjpW+oe6Fc+kTX6Cz/c1ZJKgpA+e48X+632oFC3LLfG4mlWuV6ja3sYp8HJwWGA==">
 								</div>
     <!-- PAI Internal Controls -->
     <!-- Google Tag Manager (noscript) --><noscript><iframe src='https://www.googletagmanager.com/ns.html?id=GTM-MM4PSF'height='0' width='0' style='display:none;visibility:hidden'></iframe></noscript><!-- End Google Tag Manager (noscript) -->
 
     <div id="imgPrefetch" style="display:none">
-<img src="/_layouts/15/images/spcommon.png?rev=23" />
+<img src="./PLCB Public Meetings_files/spcommon.png">
 </div>
 
     <noscript><div class='noindex'>You may be trying to access this site from a secured browser on the server. Please enable scripts and reload this page.</div></noscript>
@@ -355,13 +354,13 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
             Skip to main content
         </a>
     </div>
-    <div id="TurnOffAnimation" style="display:none;" class="s4-notdlg noindex">
-        <a id="linkTurnOffAnimation" href="#" class="ms-accessible ms-acc-button" onclick="ToggleAnimationStatus();return false;">
+    <div id="TurnOffAnimation" style="" class="s4-notdlg noindex">
+        <a id="linkTurnOffAnimation" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" class="ms-accessible ms-acc-button" onclick="ToggleAnimationStatus();return false;">
             Turn off Animations
         </a>
     </div>
     <div id="TurnOnAnimation" style="display:none;" class="s4-notdlg noindex">
-        <a id="linkTurnOnAnimation" href="#" class="ms-accessible ms-acc-button" onclick="ToggleAnimationStatus();return false;">
+        <a id="linkTurnOnAnimation" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" class="ms-accessible ms-acc-button" onclick="ToggleAnimationStatus();return false;">
             Turn on Animations
         </a>
     </div>
@@ -374,7 +373,7 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
         <div id="ms-designer-ribbon">
             <div>
 	
-	<div id="s4-ribbonrow" style="visibility:hidden;display:none"></div>
+	<div id="s4-ribbonrow" style="visibility: hidden; display: none; height: 0px;"></div>
 
 </div>
 
@@ -384,20 +383,18 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
         <span>
         </span>
     </div>
-    <div id="s4-workspace">
+    <div id="s4-workspace" style="height: 617px; width: 151px;">
         <div id="s4-bodyContainer">
             <!--SPG: Enterprise Assets Delegate Control-->
             
             <!-- Top Nav -->
             
 
-<!-- Google Translate -->
-<script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 <!-- Language Bar -->
 <div class="language-bar" id="language-bar">
     <div>
         <a href="http://www.pa.gov/">
-            <img src="../../../_layouts/15/PA.SpEnterprise.TopNav/img/pa-keystone-navy.svg" id="ctl00_ctl65_imgKeystone" alt="PA" class="h3 lang-logo" />
+            <img src="./PLCB Public Meetings_files/pa-keystone-navy.svg" id="ctl00_ctl65_imgKeystone" alt="PA" class="h3 lang-logo">
         </a>
     </div>
     <div class="language-bar-left">
@@ -407,43 +404,56 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
     </div>
 
     <div class="text-right">
-        <div id="google_translate_element"></div>
-        <a id="btn-language" href="#" alt="Translate Button">
-            <i class="fa fa-globe fa-fw"></i>
+        <div id="google_translate_element"><div class="skiptranslate goog-te-gadget" dir="ltr" style=""><div id=":0.targetLanguage" class="goog-te-gadget-simple" style="white-space: nowrap;"><img src="./PLCB Public Meetings_files/cleardot.gif" class="goog-te-gadget-icon" alt="" style="background-image: url(&quot;https://translate.googleapis.com/translate_static/img/te_ctrl3.gif&quot;); background-position: -65px 0px;"><span style="vertical-align: middle;"><a aria-haspopup="true" class="goog-te-menu-value" href="javascript:void(0)"><span>Select Language</span><img src="./PLCB Public Meetings_files/cleardot.gif" alt="" width="1" height="1"><span style="border-left: 1px solid rgb(187, 187, 187);">​</span><img src="./PLCB Public Meetings_files/cleardot.gif" alt="" width="1" height="1"><span aria-hidden="true" style="color: rgb(118, 118, 118);">▼</span></a></span></div></div></div>
+        <a id="btn-language" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" alt="Translate Button">
+            <i class="pais pai-globe pai-fw"></i>
             <span>Translate</span>
         </a>
     </div>
+    <script type="text/javascript">
+        function googleTranslateElementInit() {
+            var googleTranslateLanguages = $('[id$="hdnGoogleTransLanguagesID"]').val();
+            new google.translate.TranslateElement({ pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.SIMPLE, includedLanguages: googleTranslateLanguages }, 'google_translate_element');
+        }
+    </script>
+    <script type="text/javascript" src="./PLCB Public Meetings_files/f.txt"></script>
 </div>
 <!-- Top Navigation -->
+
 <!--Add sticky to top-nav container -->
-<div class="nav-container" id="nav-container">
-    <div class="top-bar primary-color" id="top-bar">
-        <input type="hidden" name="ctl00$ctl65$hdnGoogleTransLanguagesID" id="hdnGoogleTransLanguagesID" />
+<div class="nav-container main-nav-scrolled" id="nav-container">
+    <div class="top-bar " id="top-bar">
+        <input type="hidden" name="ctl00$ctl65$hdnGoogleTransLanguagesID" id="hdnGoogleTransLanguagesID">
 
         <div class="top-bar-title">
-            <a href="https://www.lcb.pa.gov" id="ctl00_ctl65_aHomeLink" alt="Back to Home">
+            <a href="https://www.lcb.pa.gov/" id="ctl00_ctl65_aHomeLink" alt="Back to Home">
                 <div class="top-bar-logo">
-                    <img src="https://www.lcb.pa.gov/PublishingImages/Keystone_gold.svg" id="ctl00_ctl65_imgAgencyLogoResponsive" class="agency-logo" alt="Pennsylvania Liquor Control Board" />
+                    <img src="./PLCB Public Meetings_files/Keystone_gold.svg" id="ctl00_ctl65_imgAgencyLogoResponsive" class="agency-logo" alt="Pennsylvania Liquor Control Board">
+                </div>
+                <div class="top-bar-agencyTitleSmall">
+                    <span id="ctl00_ctl65_spanAbbr">LCB</span>
                 </div>
                 <div class="top-bar-agencyTitle">
                     <span id="ctl00_ctl65_spanAcronym">Pennsylvania Liquor Control Board</span>
                 </div>
             </a>
         </div>
-        <div class="top-bar-right show-for-large">
-            <ul id="ctl00_ctl65_TopNavMenu" class="dropdown menu" data-dropdown-menu="">
-            <li><a class='top-nav-parent top-nav-top-item' href='#'>Consumers</a><i class='fa fa-chevron-down' aria-hidden='true'></i><ul class='menu vertical'><li><a href='https://www.lcb.pa.gov/Consumers/Pages/default.aspx'>Consumers</a><li><a href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?catalogId=10051&storeId=10051&langId=-1'>Store Locator</a></li><li><a href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/StoreCatalogDisplay?storeId=10051&catalogId=10051&langId=-1'>Shop Online</a></li><li><a href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/ListEvents?storeId=10051&catalogId=10051&langId=-1&VD=37'>In-Store Tasting & Events</a></li><li><a href='https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/psi_ProductDefault_Inter.asp'>Product Search</a></li><li><a href='https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/Files/productCatalog.PDF'>Product Catalog</a></li><li><a href='https://www.lcb.pa.gov/About-Us/Contact/Pages/Default.aspx'>Contact Us</a></li><li><a href='https://www.lcb.pa.gov/Consumers/Pages/Holiday-Hours.aspx'>Holiday Hours</a></li><li><a href='https://www.lcb.pa.gov/Consumers/Pages/Direct-Wine-Shipping.aspx'>Direct Wine Shipping</a></li><li><a href='https://www.lcb.pa.gov/Legal/Documents/001909.pdf'>Receiving Alcohol from Out of State</a></li><li><a href='https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch'>Search Licenses</a></li></ul></li><li><a class='top-nav-parent top-nav-top-item' href='#'>Education</a><i class='fa fa-chevron-down' aria-hidden='true'></i><ul class='menu vertical'><li><a href='https://www.lcb.pa.gov/Education/Pages/default.aspx'>Education</a><li><a href='https://www.lcb.pa.gov/Education/Programs/Pages/default.aspx'>Programs</a></li><li><a href='https://www.lcb.pa.gov/Education/Resources/Pages/default.aspx'>Resources</a></li><li><a href='https://www.lcb.pa.gov/Education/RAMP/Pages/default.aspx'>RAMP</a></li><li><a href='https://plcbplus.pa.gov/pub/Login.aspx'>PLCB+</a></li><li><a href='http://www.knowwhenknowhow.org/'>Know When. Know How.</a></li><li><a href='https://www.lcb.pa.gov/Education/Programs/Pages/Conference.aspx'>Annual Conference</a></li><li><a href='https://www.lcb.pa.gov/Education/Programs/Pages/Grants.aspx'>Grants</a></li><li><a href='https://www.lcb.pa.gov/Education/Programs/Pages/Poster-Contest.aspx'>Poster Contest</a></li><li><a href='https://www.lcb.pa.gov/About-Us/News-and-Reports/Documents/002552.pdf'>Biennial Report on Underage and High-Risk Drinking</a></li></ul></li><li><a class='top-nav-parent top-nav-top-item' href='#'>Licensing</a><i class='fa fa-chevron-down' aria-hidden='true'></i><ul class='menu vertical'><li><a href='https://www.lcb.pa.gov/Licensing/Pages/default.aspx'>Licensing</a><li><a href='https://plcbplus.pa.gov/pub/'>PLCB+</a></li><li><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/LOOP.aspx'>LOOP</a></li><li><a href='https://www.lcb.pa.gov/Licensing/Pages/Licensee-Compliance-Program.aspx'>Licensee Compliance Program</a></li><li><a href='https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch'>Search Licenses</a></li><li><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Ordering-Wine-and-Spirits.aspx'>Ordering Wine & Spirits</a></li><li><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/default.aspx'>Resources For Licensees</a></li><li><a href='https://www.lcb.pa.gov/Licensing/Topics-of-Interest/Pages/Topics-of-Interest.aspx'>Topics of Interest</a></li><li><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/WineExpandedPermits.aspx'>Wine Expanded Permits</a></li><li><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Restaurant-License-Auction.aspx'>Restaurant License Auction </a></li><li><a href='https://plcbplus.pa.gov/pub/NewProtest.aspx'>File Protest or Petition</a></li></ul></li><li><a class='top-nav-parent top-nav-top-item' href='#'>Suppliers</a><i class='fa fa-chevron-down' aria-hidden='true'></i><ul class='menu vertical'><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/default.aspx'>Suppliers</a><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/Getting-Started.aspx'>Getting Started</a></li><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/default.aspx'>Managing Existing Business</a></li><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/PA-Proud/Pages/default.aspx'>PA Proud Wine & Spirits</a></li><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/002458.pdf'>Vendor Code of Conduct (PDF)</a></li><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Documents/Policies_and_Procedures_for_Wine_and_Spirits_Vendors.pdf'>Policies & Procedures Manual</a></li><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/Forms%20and%20Resources.aspx'>Forms & Resources</a></li><li><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/2017%20SLO%20Program%20Changes%20Guide%20for%20SLO%20Suppliers.pdf'>2017 Special Order Changes Guide for Suppliers</a></li></ul></li><li><a class='top-nav-parent top-nav-top-item' href='#'>Legal</a><i class='fa fa-chevron-down' aria-hidden='true'></i><ul class='menu vertical'><li><a href='https://www.lcb.pa.gov/Legal/Pages/default.aspx'>Legal</a><li><a href='https://www.lcb.pa.gov/Legal/Pages/Act39of2016.aspx'>Act 39 of 2016</a></li><li><a href='https://www.lcb.pa.gov/Legal/Pages/Legislative-Updates.aspx'>Legislative Updates</a></li><li><a href='https://www.lcb.pa.gov/Legal/Pages/FAQs.aspx'>Legal FAQs</a></li><li><a href='https://collab.pa.gov/lcb/Extranet/Pages/Advisory-Opinions.aspx'>Advisory Opinions</a></li><li><a href='https://www.lcb.pa.gov/Legal/Pages/Advisory-Notices.aspx'>Advisory Notices</a></li><li><a href='https://govt.westlaw.com/pac/index?__lrTS=20160713132754376&transitionType=Default&contextData=(sc.Default)'>PA Liquor Code</a></li><li><a href='http://www.pacode.com/secure/data/040/040toc.html'>Board Regulations</a></li><li><a href='https://www.lcb.pa.gov/Legal/Office-of-ALJ/Pages/default.aspx'>Office of ALJ</a></li></ul></li><li><a class='top-nav-search' href='https://www.lcb.pa.gov/pages/search.aspx'><span class='show-for-sr'>Search</span><i class='fa fa-fw fa-search'></i></a></li></ul>
+        <div class="top-bar-right show-for-large" style="display: block;">
+            <nav role="navigation">
+                <ul id="ctl00_ctl65_TopNavMenu" class="dropdown menu" role="application">
+                <li class="is-dropdown-submenu-parent" aria-haspopup="true" aria-expanded="false"><a class="top-nav-parent top-nav-top-item" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#">Consumers</a><ul class="menu vertical dropdown submenu is-dropdown-submenu" role="menu" aria-label="submenu"><li role="menuitem"><a href="https://www.lcb.pa.gov/Consumers/Pages/default.aspx">Consumers</a></li><li><a href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?catalogId=10051&amp;storeId=10051&amp;langId=-1" class="external" target="_blank">Store Locator<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li><li><a href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/StoreCatalogDisplay?storeId=10051&amp;catalogId=10051&amp;langId=-1" class="external" target="_blank">Shop Online<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li><li><a href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/ListEvents?storeId=10051&amp;catalogId=10051&amp;langId=-1&amp;VD=37" class="external" target="_blank">In-Store Tasting &amp; Events<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li><li><a href="https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/psi_ProductDefault_Inter.asp">Product Search</a></li><li><a href="https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/Files/productCatalog.PDF">Product Catalog</a></li><li><a href="https://www.lcb.pa.gov/About-Us/Contact/Pages/Default.aspx">Contact Us</a></li><li><a href="https://www.lcb.pa.gov/Consumers/Pages/Holiday-Hours.aspx">Holiday Hours</a></li><li><a href="https://www.lcb.pa.gov/Consumers/Pages/Direct-Wine-Shipping.aspx">Direct Wine Shipping</a></li><li><a href="https://www.lcb.pa.gov/Legal/Documents/001909.pdf">Receiving Alcohol from Out of </a></li><li><a href="https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch">Search Licenses</a></li></ul></li><li class="is-dropdown-submenu-parent" aria-haspopup="true" aria-expanded="false"><a class="top-nav-parent top-nav-top-item" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#">Education</a><ul class="menu vertical dropdown submenu is-dropdown-submenu" role="menu" aria-label="submenu"><li role="menuitem"><a href="https://www.lcb.pa.gov/Education/Pages/default.aspx">Education</a></li><li><a href="https://www.lcb.pa.gov/Education/Programs/Pages/default.aspx">Programs</a></li><li><a href="https://www.lcb.pa.gov/Education/Resources/Pages/default.aspx">Resources</a></li><li><a href="https://www.lcb.pa.gov/Education/RAMP/Pages/default.aspx">RAMP</a></li><li><a href="https://plcbplus.pa.gov/pub/Login.aspx">PLCB+</a></li><li><a href="http://www.knowwhenknowhow.org/" class="external" target="_blank">Know When. Know How.<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li><li><a href="https://www.lcb.pa.gov/Education/Programs/Pages/Conference.aspx">Annual Conference</a></li><li><a href="https://www.lcb.pa.gov/Education/Programs/Pages/Grants.aspx">Grants</a></li><li><a href="https://www.lcb.pa.gov/Education/Programs/Pages/Poster-Contest.aspx">Poster Contest</a></li><li><a href="https://www.lcb.pa.gov/About-Us/News-and-Reports/Documents/002552.pdf">Biennial Report on Underage an</a></li></ul></li><li class="is-dropdown-submenu-parent" aria-haspopup="true" aria-expanded="false"><a class="top-nav-parent top-nav-top-item" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#">Licensing</a><ul class="menu vertical dropdown submenu is-dropdown-submenu" role="menu" aria-label="submenu"><li role="menuitem"><a href="https://www.lcb.pa.gov/Licensing/Pages/default.aspx">Licensing</a></li><li><a href="https://plcbplus.pa.gov/pub/">PLCB+</a></li><li><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/LOOP.aspx">LOOP</a></li><li><a href="https://www.lcb.pa.gov/Licensing/Pages/Licensee-Compliance-Program.aspx">Licensee Compliance Program</a></li><li><a href="https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch">Search Licenses</a></li><li><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Ordering-Wine-and-Spirits.aspx">Ordering Wine &amp; Spirits</a></li><li><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/default.aspx">Resources For Licensees</a></li><li><a href="https://www.lcb.pa.gov/Licensing/Topics-of-Interest/Pages/Topics-of-Interest.aspx">Topics of Interest</a></li><li><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/WineExpandedPermits.aspx">Wine Expanded Permits</a></li><li><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Restaurant-License-Auction.aspx">Restaurant License Auction </a></li><li><a href="https://plcbplus.pa.gov/pub/NewProtest.aspx">File Protest or Petition</a></li></ul></li><li class="is-dropdown-submenu-parent" aria-haspopup="true" aria-expanded="false"><a class="top-nav-parent top-nav-top-item" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#">Suppliers</a><ul class="menu vertical dropdown submenu is-dropdown-submenu" role="menu" aria-label="submenu"><li role="menuitem"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/default.aspx">Suppliers</a></li><li><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/Getting-Started.aspx">Getting Started</a></li><li><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/default.aspx">Managing Existing Business</a></li><li><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/PA-Proud/Pages/default.aspx">PA Proud Wine &amp; Spirits</a></li><li><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/002458.pdf">Vendor Code of Conduct (PDF)</a></li><li><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Documents/Policies_and_Procedures_for_Wine_and_Spirits_Vendors.pdf">Policies &amp; Procedures Manual</a></li><li><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/Forms%20and%20Resources.aspx">Forms &amp; Resources</a></li><li><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/2017%20SLO%20Program%20Changes%20Guide%20for%20SLO%20Suppliers.pdf">2017 Special Order Changes Gui</a></li></ul></li><li class="is-dropdown-submenu-parent" aria-haspopup="true" aria-expanded="false"><a class="top-nav-parent top-nav-top-item" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#">Legal</a><ul class="menu vertical dropdown submenu is-dropdown-submenu" role="menu" aria-label="submenu"><li role="menuitem"><a href="https://www.lcb.pa.gov/Legal/Pages/default.aspx">Legal</a></li><li><a href="https://www.lcb.pa.gov/Legal/Pages/Act39of2016.aspx">Act 39 of 2016</a></li><li><a href="https://www.lcb.pa.gov/Legal/Pages/Legislative-Updates.aspx">Legislative Updates</a></li><li><a href="https://www.lcb.pa.gov/Legal/Pages/FAQs.aspx">Legal FAQs</a></li><li><a href="https://collab.pa.gov/lcb/Extranet/Pages/Advisory-Opinions.aspx">Advisory Opinions</a></li><li><a href="https://www.lcb.pa.gov/Legal/Pages/Advisory-Notices.aspx">Advisory Notices</a></li><li><a href="https://govt.westlaw.com/pac/Browse/Home/Pennsylvania/UnofficialPurdonsPennsylvaniaStatutes?guid=ND1A91B3BFF81436C9BB9A57A71893DCC&amp;originationContext=documenttoc&amp;transitionType=Default&amp;contextData=(sc.Default)" class="external" target="_blank">PA Liquor Code<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li><li><a href="http://www.pacode.com/secure/data/040/040toc.html" class="external" target="_blank">Board Regulations<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li><li><a href="https://www.lcb.pa.gov/Legal/Office-of-ALJ/Pages/default.aspx">Office of ALJ</a></li></ul></li><li><a class="top-nav-search" href="https://www.lcb.pa.gov/pages/search.aspx"><span class="show-for-sr">Search</span><i class="pair pai-fw pai-search"></i></a></li></ul>
+            </nav>
         </div>
-        <div class="top-bar-right hide-for-large">
+        <div class="top-bar-right hide-for-large" style="display: block;">
             <ul class="menu">
                 <li>
-                    <a href="https://www.lcb.pa.gov/pages/search.aspx" id="ctl00_ctl65_mobileSearch"><span class="show-for-sr">Search</span><i class="fa fa-search fa-fw"></i></a>
+                    <a href="https://www.lcb.pa.gov/pages/search.aspx" id="ctl00_ctl65_mobileSearch"><span class="show-for-sr">Search</span><i class="pais pai-search pai-fw"></i></a>
                 </li>
                 <li>
                     <div class="nav-divider"></div>
                 </li>
                 <li>
-                    <a id="topNavMenuBtn" class="menu-button mobile-menu" href="#" data-toggle="topNavMobileNav">
+                    <a id="topNavMenuBtn" class="menu-button mobile-menu" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" data-toggle="topNavMobileNav" aria-expanded="false" aria-controls="topNavMobileNav">
                         <div id="openMenu">
                             <div id="nav-icon1">
                                 <span></span>
@@ -457,24 +467,24 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
             </ul>
         </div>
     </div>
-    <div id="topNavMobileNav" class="hide-for-large nav-container-mobile is-closed off-canvas position-left" data-off-canvas="" data-content-overlay="false" aria-hidden="true">
-        <div class="top-bar primary-color" id="top-bar-mobile">
+    <div id="topNavMobileNav" class="hide-for-large nav-container-mobile is-closed off-canvas position-left is-transition-overlap" data-off-canvas="" data-content-overlay="false" aria-hidden="true" data-e="d6k42d-e">
+        <div class="top-bar" id="top-bar-mobile">
             <div class="top-bar-title title-overlay">
-                <a href="https://www.lcb.pa.gov" id="ctl00_ctl65_aHomeLinkMobile">
+                <a href="https://www.lcb.pa.gov/" id="ctl00_ctl65_aHomeLinkMobile">
                     <div class="top-bar-logo">
-                        <img src="https://www.lcb.pa.gov/PublishingImages/Keystone_gold.svg" id="ctl00_ctl65_imgAgencyLogoMobile" class="agency-logo" alt="Pennsylvania Liquor Control Board" />
+                        <img src="./PLCB Public Meetings_files/Keystone_gold.svg" id="ctl00_ctl65_imgAgencyLogoMobile" class="agency-logo" alt="Pennsylvania Liquor Control Board">
                     </div>
                     <div class="top-bar-agencyTitle">
                         <span id="ctl00_ctl65_spanAcronymMobile" class="hide-for-large">Pennsylvania Liquor Control Board</span>
                     </div>
                 </a>
             </div>
-            <div class="top-bar-right hide-for-large">
+            <div class="top-bar-right hide-for-large" style="display: block;">
                 <ul class="menu">
                     <li>
-                        <a id="AccordianMenuBtn" class="menu-button mobile-menu" href="#" data-toggle="topNavMobileNav">
+                        <a id="AccordianMenuBtn" class="menu-button mobile-menu" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" data-toggle="topNavMobileNav" aria-expanded="false" aria-controls="topNavMobileNav">
                             <div id="closeMenu">
-                                <i class="fa fa-times" aria-hidden="true"></i>
+                                <i class="pais pai-times" aria-hidden="true"></i>
                             </div>
                             <span class="menu-title">Menu</span>
                         </a>
@@ -482,49 +492,49 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
                 </ul>
             </div>
         </div>
-        <div class="accordion mobile-accordion" data-accordion="ymsj7y-accordion" data-allow-all-closed="true" role="tablist">
+        <div class="accordion mobile-accordion" data-accordion="ymsj7y-accordion" data-allow-all-closed="true" role="tablist" data-e="wsr37i-e">
             
-                    <div id="ctl00_ctl65_rptAccordion_ctl00_divAccordionItem" class="accordion-item primary-color" data-accordion-item="">
-                        <a id="ctl00_ctl65_rptAccordion_ctl00_lnkAccordionTitle" class="accordion-title primary-color" href="../../../_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#">Consumers</a>
-                        <div class="accordion-content" data-tab-content="">
+                    <div id="ctl00_ctl65_rptAccordion_ctl00_divAccordionItem" class="accordion-item " data-accordion-item="">
+                        <a id="ctl00_ctl65_rptAccordion_ctl00_divAccordionItem" class="accordion-title " href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#" aria-controls="42fhop-accordion" role="tab" aria-expanded="false" aria-selected="false">Consumers</a>
+                        <div class="accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl65_rptAccordion_ctl00_divAccordionItem" aria-hidden="true" id="42fhop-accordion">
                             <ul id="ctl00_ctl65_rptAccordion_ctl00_ulAccordionList" class="accordion-list">
-                            <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Consumers/Pages/default.aspx' class='accordion-link primary-hover'>Consumers</a></li> <li class='accordion-list-item'><a href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?catalogId=10051&storeId=10051&langId=-1' class='accordion-link primary-hover'>Store Locator</a></li> <li class='accordion-list-item'><a href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/StoreCatalogDisplay?storeId=10051&catalogId=10051&langId=-1' class='accordion-link primary-hover'>Shop Online</a></li> <li class='accordion-list-item'><a href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/ListEvents?storeId=10051&catalogId=10051&langId=-1&VD=37' class='accordion-link primary-hover'>In-Store Tasting & Events</a></li> <li class='accordion-list-item'><a href='https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/psi_ProductDefault_Inter.asp' class='accordion-link primary-hover'>Product Search</a></li> <li class='accordion-list-item'><a href='https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/Files/productCatalog.PDF' class='accordion-link primary-hover'>Product Catalog</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/About-Us/Contact/Pages/Default.aspx' class='accordion-link primary-hover'>Contact Us</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Consumers/Pages/Holiday-Hours.aspx' class='accordion-link primary-hover'>Holiday Hours</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Consumers/Pages/Direct-Wine-Shipping.aspx' class='accordion-link primary-hover'>Direct Wine Shipping</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Legal/Documents/001909.pdf' class='accordion-link primary-hover'>Receiving Alcohol from Out of State</a></li> <li class='accordion-list-item'><a href='https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch' class='accordion-link primary-hover'>Search Licenses</a></li> </ul>
+                            <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Consumers/Pages/default.aspx" class="accordion-link primary-hover">Consumers</a></li> <li class="accordion-list-item"><a href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?catalogId=10051&amp;storeId=10051&amp;langId=-1" class="accordion-link primary-hover external" target="_blank">Store Locator<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li> <li class="accordion-list-item"><a href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/StoreCatalogDisplay?storeId=10051&amp;catalogId=10051&amp;langId=-1" class="accordion-link primary-hover external" target="_blank">Shop Online<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li> <li class="accordion-list-item"><a href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/ListEvents?storeId=10051&amp;catalogId=10051&amp;langId=-1&amp;VD=37" class="accordion-link primary-hover external" target="_blank">In-Store Tasting &amp; Events<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li> <li class="accordion-list-item"><a href="https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/psi_ProductDefault_Inter.asp" class="accordion-link primary-hover">Product Search</a></li> <li class="accordion-list-item"><a href="https://www.lcbapps.lcb.state.pa.us/webapp/Product_Management/Files/productCatalog.PDF" class="accordion-link primary-hover">Product Catalog</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/About-Us/Contact/Pages/Default.aspx" class="accordion-link primary-hover">Contact Us</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Consumers/Pages/Holiday-Hours.aspx" class="accordion-link primary-hover">Holiday Hours</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Consumers/Pages/Direct-Wine-Shipping.aspx" class="accordion-link primary-hover">Direct Wine Shipping</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Legal/Documents/001909.pdf" class="accordion-link primary-hover">Receiving Alcohol from Out of </a></li> <li class="accordion-list-item"><a href="https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch" class="accordion-link primary-hover">Search Licenses</a></li> </ul>
                         </div>
                     </div>
                     
                 
-                    <div id="ctl00_ctl65_rptAccordion_ctl01_divAccordionItem" class="accordion-item primary-color" data-accordion-item="">
-                        <a id="ctl00_ctl65_rptAccordion_ctl01_lnkAccordionTitle" class="accordion-title primary-color" href="../../../_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#">Education</a>
-                        <div class="accordion-content" data-tab-content="">
+                    <div id="ctl00_ctl65_rptAccordion_ctl01_divAccordionItem" class="accordion-item " data-accordion-item="">
+                        <a id="ctl00_ctl65_rptAccordion_ctl01_divAccordionItem" class="accordion-title " href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#" aria-controls="o0t5b0-accordion" role="tab" aria-expanded="false" aria-selected="false">Education</a>
+                        <div class="accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl65_rptAccordion_ctl01_divAccordionItem" aria-hidden="true" id="o0t5b0-accordion">
                             <ul id="ctl00_ctl65_rptAccordion_ctl01_ulAccordionList" class="accordion-list">
-                            <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Education/Pages/default.aspx' class='accordion-link primary-hover'>Education</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Education/Programs/Pages/default.aspx' class='accordion-link primary-hover'>Programs</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Education/Resources/Pages/default.aspx' class='accordion-link primary-hover'>Resources</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Education/RAMP/Pages/default.aspx' class='accordion-link primary-hover'>RAMP</a></li> <li class='accordion-list-item'><a href='https://plcbplus.pa.gov/pub/Login.aspx' class='accordion-link primary-hover'>PLCB+</a></li> <li class='accordion-list-item'><a href='http://www.knowwhenknowhow.org/' class='accordion-link primary-hover'>Know When. Know How.</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Education/Programs/Pages/Conference.aspx' class='accordion-link primary-hover'>Annual Conference</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Education/Programs/Pages/Grants.aspx' class='accordion-link primary-hover'>Grants</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Education/Programs/Pages/Poster-Contest.aspx' class='accordion-link primary-hover'>Poster Contest</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/About-Us/News-and-Reports/Documents/002552.pdf' class='accordion-link primary-hover'>Biennial Report on Underage and High-Risk Drinking</a></li> </ul>
+                            <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Education/Pages/default.aspx" class="accordion-link primary-hover">Education</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Education/Programs/Pages/default.aspx" class="accordion-link primary-hover">Programs</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Education/Resources/Pages/default.aspx" class="accordion-link primary-hover">Resources</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Education/RAMP/Pages/default.aspx" class="accordion-link primary-hover">RAMP</a></li> <li class="accordion-list-item"><a href="https://plcbplus.pa.gov/pub/Login.aspx" class="accordion-link primary-hover">PLCB+</a></li> <li class="accordion-list-item"><a href="http://www.knowwhenknowhow.org/" class="accordion-link primary-hover external" target="_blank">Know When. Know How.<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Education/Programs/Pages/Conference.aspx" class="accordion-link primary-hover">Annual Conference</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Education/Programs/Pages/Grants.aspx" class="accordion-link primary-hover">Grants</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Education/Programs/Pages/Poster-Contest.aspx" class="accordion-link primary-hover">Poster Contest</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/About-Us/News-and-Reports/Documents/002552.pdf" class="accordion-link primary-hover">Biennial Report on Underage an</a></li> </ul>
                         </div>
                     </div>
                     
                 
-                    <div id="ctl00_ctl65_rptAccordion_ctl02_divAccordionItem" class="accordion-item primary-color" data-accordion-item="">
-                        <a id="ctl00_ctl65_rptAccordion_ctl02_lnkAccordionTitle" class="accordion-title primary-color" href="../../../_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#">Licensing</a>
-                        <div class="accordion-content" data-tab-content="">
+                    <div id="ctl00_ctl65_rptAccordion_ctl02_divAccordionItem" class="accordion-item " data-accordion-item="">
+                        <a id="ctl00_ctl65_rptAccordion_ctl02_divAccordionItem" class="accordion-title " href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#" aria-controls="j3llbn-accordion" role="tab" aria-expanded="false" aria-selected="false">Licensing</a>
+                        <div class="accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl65_rptAccordion_ctl02_divAccordionItem" aria-hidden="true" id="j3llbn-accordion">
                             <ul id="ctl00_ctl65_rptAccordion_ctl02_ulAccordionList" class="accordion-list">
-                            <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/Pages/default.aspx' class='accordion-link primary-hover'>Licensing</a></li> <li class='accordion-list-item'><a href='https://plcbplus.pa.gov/pub/' class='accordion-link primary-hover'>PLCB+</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/LOOP.aspx' class='accordion-link primary-hover'>LOOP</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/Pages/Licensee-Compliance-Program.aspx' class='accordion-link primary-hover'>Licensee Compliance Program</a></li> <li class='accordion-list-item'><a href='https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch' class='accordion-link primary-hover'>Search Licenses</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Ordering-Wine-and-Spirits.aspx' class='accordion-link primary-hover'>Ordering Wine & Spirits</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/default.aspx' class='accordion-link primary-hover'>Resources For Licensees</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/Topics-of-Interest/Pages/Topics-of-Interest.aspx' class='accordion-link primary-hover'>Topics of Interest</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/WineExpandedPermits.aspx' class='accordion-link primary-hover'>Wine Expanded Permits</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Restaurant-License-Auction.aspx' class='accordion-link primary-hover'>Restaurant License Auction </a></li> <li class='accordion-list-item'><a href='https://plcbplus.pa.gov/pub/NewProtest.aspx' class='accordion-link primary-hover'>File Protest or Petition</a></li> </ul>
+                            <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/Pages/default.aspx" class="accordion-link primary-hover">Licensing</a></li> <li class="accordion-list-item"><a href="https://plcbplus.pa.gov/pub/" class="accordion-link primary-hover">PLCB+</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/LOOP.aspx" class="accordion-link primary-hover">LOOP</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/Pages/Licensee-Compliance-Program.aspx" class="accordion-link primary-hover">Licensee Compliance Program</a></li> <li class="accordion-list-item"><a href="https://plcbplus.pa.gov/pub/Default.aspx?PossePresentation=LicenseSearch" class="accordion-link primary-hover">Search Licenses</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Ordering-Wine-and-Spirits.aspx" class="accordion-link primary-hover">Ordering Wine &amp; Spirits</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/default.aspx" class="accordion-link primary-hover">Resources For Licensees</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/Topics-of-Interest/Pages/Topics-of-Interest.aspx" class="accordion-link primary-hover">Topics of Interest</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/WineExpandedPermits.aspx" class="accordion-link primary-hover">Wine Expanded Permits</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Licensing/ResourcesForLicensees/Pages/Restaurant-License-Auction.aspx" class="accordion-link primary-hover">Restaurant License Auction </a></li> <li class="accordion-list-item"><a href="https://plcbplus.pa.gov/pub/NewProtest.aspx" class="accordion-link primary-hover">File Protest or Petition</a></li> </ul>
                         </div>
                     </div>
                     
                 
-                    <div id="ctl00_ctl65_rptAccordion_ctl03_divAccordionItem" class="accordion-item primary-color" data-accordion-item="">
-                        <a id="ctl00_ctl65_rptAccordion_ctl03_lnkAccordionTitle" class="accordion-title primary-color" href="../../../_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#">Suppliers</a>
-                        <div class="accordion-content" data-tab-content="">
+                    <div id="ctl00_ctl65_rptAccordion_ctl03_divAccordionItem" class="accordion-item " data-accordion-item="">
+                        <a id="ctl00_ctl65_rptAccordion_ctl03_divAccordionItem" class="accordion-title " href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#" aria-controls="e1edf2-accordion" role="tab" aria-expanded="false" aria-selected="false">Suppliers</a>
+                        <div class="accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl65_rptAccordion_ctl03_divAccordionItem" aria-hidden="true" id="e1edf2-accordion">
                             <ul id="ctl00_ctl65_rptAccordion_ctl03_ulAccordionList" class="accordion-list">
-                            <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/default.aspx' class='accordion-link primary-hover'>Suppliers</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/Getting-Started.aspx' class='accordion-link primary-hover'>Getting Started</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/default.aspx' class='accordion-link primary-hover'>Managing Existing Business</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/PA-Proud/Pages/default.aspx' class='accordion-link primary-hover'>PA Proud Wine & Spirits</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/002458.pdf' class='accordion-link primary-hover'>Vendor Code of Conduct (PDF)</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Documents/Policies_and_Procedures_for_Wine_and_Spirits_Vendors.pdf' class='accordion-link primary-hover'>Policies & Procedures Manual</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/Forms%20and%20Resources.aspx' class='accordion-link primary-hover'>Forms & Resources</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/2017%20SLO%20Program%20Changes%20Guide%20for%20SLO%20Suppliers.pdf' class='accordion-link primary-hover'>2017 Special Order Changes Guide for Suppliers</a></li> </ul>
+                            <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/default.aspx" class="accordion-link primary-hover">Suppliers</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Pages/Getting-Started.aspx" class="accordion-link primary-hover">Getting Started</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/default.aspx" class="accordion-link primary-hover">Managing Existing Business</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/PA-Proud/Pages/default.aspx" class="accordion-link primary-hover">PA Proud Wine &amp; Spirits</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/002458.pdf" class="accordion-link primary-hover">Vendor Code of Conduct (PDF)</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Documents/Policies_and_Procedures_for_Wine_and_Spirits_Vendors.pdf" class="accordion-link primary-hover">Policies &amp; Procedures Manual</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Managing-Existing-Business/Pages/Forms%20and%20Resources.aspx" class="accordion-link primary-hover">Forms &amp; Resources</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Wine-and-Spirits-Suppliers/Documents/2017%20SLO%20Program%20Changes%20Guide%20for%20SLO%20Suppliers.pdf" class="accordion-link primary-hover">2017 Special Order Changes Gui</a></li> </ul>
                         </div>
                     </div>
                     
                 
-                    <div id="ctl00_ctl65_rptAccordion_ctl04_divAccordionItem" class="accordion-item primary-color" data-accordion-item="">
-                        <a id="ctl00_ctl65_rptAccordion_ctl04_lnkAccordionTitle" class="accordion-title primary-color" href="../../../_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#">Legal</a>
-                        <div class="accordion-content" data-tab-content="">
+                    <div id="ctl00_ctl65_rptAccordion_ctl04_divAccordionItem" class="accordion-item " data-accordion-item="">
+                        <a id="ctl00_ctl65_rptAccordion_ctl04_divAccordionItem" class="accordion-title " href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SPEnterprise.TopNav/#" aria-controls="v3ni9u-accordion" role="tab" aria-expanded="false" aria-selected="false">Legal</a>
+                        <div class="accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl65_rptAccordion_ctl04_divAccordionItem" aria-hidden="true" id="v3ni9u-accordion">
                             <ul id="ctl00_ctl65_rptAccordion_ctl04_ulAccordionList" class="accordion-list">
-                            <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Legal/Pages/default.aspx' class='accordion-link primary-hover'>Legal</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Legal/Pages/Act39of2016.aspx' class='accordion-link primary-hover'>Act 39 of 2016</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Legal/Pages/Legislative-Updates.aspx' class='accordion-link primary-hover'>Legislative Updates</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Legal/Pages/FAQs.aspx' class='accordion-link primary-hover'>Legal FAQs</a></li> <li class='accordion-list-item'><a href='https://collab.pa.gov/lcb/Extranet/Pages/Advisory-Opinions.aspx' class='accordion-link primary-hover'>Advisory Opinions</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Legal/Pages/Advisory-Notices.aspx' class='accordion-link primary-hover'>Advisory Notices</a></li> <li class='accordion-list-item'><a href='https://govt.westlaw.com/pac/index?__lrTS=20160713132754376&transitionType=Default&contextData=(sc.Default)' class='accordion-link primary-hover'>PA Liquor Code</a></li> <li class='accordion-list-item'><a href='http://www.pacode.com/secure/data/040/040toc.html' class='accordion-link primary-hover'>Board Regulations</a></li> <li class='accordion-list-item'><a href='https://www.lcb.pa.gov/Legal/Office-of-ALJ/Pages/default.aspx' class='accordion-link primary-hover'>Office of ALJ</a></li> </ul>
+                            <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Legal/Pages/default.aspx" class="accordion-link primary-hover">Legal</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Legal/Pages/Act39of2016.aspx" class="accordion-link primary-hover">Act 39 of 2016</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Legal/Pages/Legislative-Updates.aspx" class="accordion-link primary-hover">Legislative Updates</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Legal/Pages/FAQs.aspx" class="accordion-link primary-hover">Legal FAQs</a></li> <li class="accordion-list-item"><a href="https://collab.pa.gov/lcb/Extranet/Pages/Advisory-Opinions.aspx" class="accordion-link primary-hover">Advisory Opinions</a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Legal/Pages/Advisory-Notices.aspx" class="accordion-link primary-hover">Advisory Notices</a></li> <li class="accordion-list-item"><a href="https://govt.westlaw.com/pac/Browse/Home/Pennsylvania/UnofficialPurdonsPennsylvaniaStatutes?guid=ND1A91B3BFF81436C9BB9A57A71893DCC&amp;originationContext=documenttoc&amp;transitionType=Default&amp;contextData=(sc.Default)" class="accordion-link primary-hover external" target="_blank">PA Liquor Code<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li> <li class="accordion-list-item"><a href="http://www.pacode.com/secure/data/040/040toc.html" class="accordion-link primary-hover external" target="_blank">Board Regulations<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></li> <li class="accordion-list-item"><a href="https://www.lcb.pa.gov/Legal/Office-of-ALJ/Pages/default.aspx" class="accordion-link primary-hover">Office of ALJ</a></li> </ul>
                         </div>
                     </div>
                     
@@ -538,28 +548,35 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
             <div id="ms-belltown-table" class="ms-table">
                 <div class="ms-tableRow">
                 </div>
-                <div class="banner" style="height:340px; background-size:cover;">
+                <div class="banner" role="banner" style="height:340px; background-size:cover;" aria-label="">
+                    <div class="TextContainer">
+                        <h1 id="bannerHeader" style="display:none;" class="BannerHeading"></h1>
+                        <h2 id="bannerSubheader" style="display:none;" class="BannerSubtext"></h2>
+                        <p id="buttonText" style="display:none!important"></p> 
+                        <a id="BannerButtonLink" style="display:none" role="link" aria-labelledby="buttonText" class="morebutton button primary-color BannerButton"></a>
+                    </div>
+                    <div id="BannerArrows">
+                        <button type="button" role="button" id="BannerPrev" style="display:none;" aria-label="Previous Carousel Content" href="#" class="pais pai-angle-left" onclick="setCustIndex(&#39;prev&#39;)"></button>
+                        <button type="button" role="button" id="BannerNext" style="display:none;" aria-label="Next Carousel Content" href="#" class="pais pai-angle-right" onclick="setCustIndex(&#39;next&#39;)"></button>
+                    </div>
                 </div>
                 <!-- Icon Bar -->
                 <div id="ctl00_ctl67_divIconBarContainer" class="iconbar-container show-for-medium">
     <ul id="ctl00_ctl67_divIconBar" class="row full-width small-up-1 medium-up-5 large-up-8 iconbar menu" role="list">
-
     </ul>
 </div>
 
 <div class="Icon_Bar_Wrapper">
-<nav id="ctl00_ctl67_Icon_Bar_Nav" class="Icon_Bar">
-    
-    <div id="ctl00_ctl67_productNavContent" data-equalizer="" class="Icon_Bar_Contents"><div><a class='Icon_Bar_Link' data-equalizer-watch='' href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?catalogId=10051&storeId=10051&langId=-1'> <i class='fa-map-pin'></i><span>Store Locator</span></a></div><div><a class='Icon_Bar_Link' data-equalizer-watch='' href='http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/StoreCatalogDisplay?storeId=10051&catalogId=10051&langId=-1'> <i class='fa-cart-plus'></i><span>Shop Online</span></a></div><div><a class='Icon_Bar_Link' data-equalizer-watch='' href='https://www.lcb.pa.gov/About-Us/Contact/Pages/Default.aspx'> <i class='fa-envelope-open-o'></i><span>Contact Us</span></a></div><div><a class='Icon_Bar_Link' data-equalizer-watch='' href='https://www.lcb.pa.gov/WorkWithUs/Pages/default.aspx'> <i class='fa-handshake-o'></i><span>Work With Us</span></a></div><div><a class='Icon_Bar_Link' data-equalizer-watch='' href='https://www.lcb.pa.gov/About-Us/News-and-Reports/Pages/default.aspx'> <i class='fa-folder-open-o'></i><span>News/Reports</span></a></div><div><a class='Icon_Bar_Link' data-equalizer-watch='' href='https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx'> <i class='fa-legal'></i><span>Board Meetings</span></a></div><div><a class='Icon_Bar_Link' data-equalizer-watch='' href='https://www.lcb.pa.gov/About-Us/Pages/default.aspx'> <i class='fa-group'></i><span>About Us</span></a></div></div>
-</nav>
-
+    <nav id="ctl00_ctl67_Icon_Bar_Nav" class="Icon_Bar">
+        <div id="ctl00_ctl67_productNavContent" data-equalizer="" class="Icon_Bar_Contents slick-initialized slick-slider" style="display: block;" data-resize="9efzg9-eq" data-mutate="8q6poj-eq" data-e="4qgwuq-e" data-events="mutate"><div aria-live="polite" class="slick-list draggable" tabindex="0"><div class="slick-track" style="opacity: 1; width: 247px; transform: translate3d(-57px, 0px, 0px);"><div class="slick-slide slick-cloned" aria-hidden="true" style="width: 19px;" data-slick-index="-3"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/News-and-Reports/Pages/default.aspx" style="height: auto;"> <i class="pair pai-folder-open"></i><span>News/Reports</span></a></div><div class="slick-slide slick-cloned" aria-hidden="true" style="width: 19px;" data-slick-index="-2"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx" style="height: auto;"> <i class="pair pai-calendar"></i><span>Board Meetings</span></a></div><div class="slick-slide slick-cloned" aria-hidden="true" style="width: 19px;" data-slick-index="-1"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/Pages/default.aspx" style="height: auto;"> <i class="pair pai-users"></i><span>About Us</span></a></div><div class="slick-slide slick-active" aria-hidden="false" style="width: 19px;" data-slick-index="0"><a class="Icon_Bar_Link external" data-equalizer-watch="" href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?catalogId=10051&amp;storeId=10051&amp;langId=-1" target="_blank" style="height: 286px;"> <i class="pair pai-map-pin"></i><span>Store Locator</span><span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></div><div class="slick-slide slick-active" aria-hidden="false" style="width: 19px;" data-slick-index="1"><a class="Icon_Bar_Link external" data-equalizer-watch="" href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/StoreCatalogDisplay?storeId=10051&amp;catalogId=10051&amp;langId=-1" target="_blank" style="height: 286px;"> <i class="pair pai-cart-plus"></i><span>Shop Online</span><span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></div><div class="slick-slide slick-active" aria-hidden="false" style="width: 19px;" data-slick-index="2"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/Contact/Pages/default.aspx" style="height: 286px;"> <i class="pair pai-envelope-open"></i><span>Contact Us</span></a></div><div class="slick-slide" aria-hidden="true" style="width: 19px;" data-slick-index="3"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/JoinOurTeam/Pages/default.aspx" style="height: 286px;"> <i class="pair pai-handshake"></i><span>Join Our Team</span></a></div><div class="slick-slide" aria-hidden="true" style="width: 19px;" data-slick-index="4"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/News-and-Reports/Pages/default.aspx" style="height: 286px;"> <i class="pair pai-folder-open"></i><span>News/Reports</span></a></div><div class="slick-slide" aria-hidden="true" style="width: 19px;" data-slick-index="5"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx" style="height: 286px;"> <i class="pair pai-calendar"></i><span>Board Meetings</span></a></div><div class="slick-slide" aria-hidden="true" style="width: 19px;" data-slick-index="6"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/Pages/default.aspx" style="height: 286px;"> <i class="pair pai-users"></i><span>About Us</span></a></div><div class="slick-slide slick-cloned" aria-hidden="true" style="width: 19px;" data-slick-index="7"><a class="Icon_Bar_Link external" data-equalizer-watch="" href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/FindStoreView?catalogId=10051&amp;storeId=10051&amp;langId=-1" target="_blank" style="height: auto;"> <i class="pair pai-map-pin"></i><span>Store Locator</span><span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></div><div class="slick-slide slick-cloned" aria-hidden="true" style="width: 19px;" data-slick-index="8"><a class="Icon_Bar_Link external" data-equalizer-watch="" href="http://www.finewineandgoodspirits.com/webapp/wcs/stores/servlet/StoreCatalogDisplay?storeId=10051&amp;catalogId=10051&amp;langId=-1" target="_blank" style="height: auto;"> <i class="pair pai-cart-plus"></i><span>Shop Online</span><span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a></div><div class="slick-slide slick-cloned" aria-hidden="true" style="width: 19px;" data-slick-index="9"><a class="Icon_Bar_Link" data-equalizer-watch="" href="https://www.lcb.pa.gov/About-Us/Contact/Pages/default.aspx" style="height: auto;"> <i class="pair pai-envelope-open"></i><span>Contact Us</span></a></div></div></div><button type="button" data-role="none" class="slick-prev pair pai-chevron-left" aria-label="previous" style=""></button><button type="button" data-role="none" class="slick-next pair pai-chevron-right" aria-label="next" style=""></button></div>
+    </nav>
 </div>
 
                 <div id="page" class="primary">
                     <div id="wrap">
                         <nav class="row column breadcrumbs text-left" aria-label="Breadcrumb">
                             <!--SPG: Breadcrumb -->
-                            <span SiteMapProviders="SPSiteMapProvider,SPXmlContentMapProvider" HideInteriorRootNodes="true"><span><a class="breadcrumbRootNode" href="/Pages/default.aspx">PLCB</a></span><span> &gt; </span><span><a class="breadcrumbNode" href="/About-Us/Pages/default.aspx">About</a></span><span> &gt; </span><span><a class="breadcrumbNode" href="/About-Us/Board/Pages/default.aspx">Board</a></span><span> &gt; </span><span class="breadcrumbCurrentNode">PLCB Public Meetings</span></span>
+                            <span sitemapproviders="SPSiteMapProvider,SPXmlContentMapProvider" hideinteriorrootnodes="true"><span><a class="breadcrumbRootNode" href="https://www.lcb.pa.gov/Pages/default.aspx">PLCB</a></span><span> &gt; </span><span><a class="breadcrumbNode" href="https://www.lcb.pa.gov/About-Us/Pages/default.aspx">About</a></span><span> &gt; </span><span><a class="breadcrumbNode" href="https://www.lcb.pa.gov/About-Us/Board/Pages/default.aspx">Board</a></span><span> &gt; </span><span class="breadcrumbCurrentNode">PLCB Public Meetings</span></span>
                         </nav>
                         <div class="contentwrapper">
                             <div class="ms-table ms-fullWidth">
@@ -584,23 +601,23 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
                     <div data-name="Page Field: Page Content">
                         
                         
-                        <div id="ctl00_PlaceHolderMain_PageContent_label" style='display:none'>Page Content</div><div id="ctl00_PlaceHolderMain_PageContent__ControlWrapper_RichHtmlField" class="ms-rtestate-field" style="display:inline" aria-labelledby="ctl00_PlaceHolderMain_PageContent_label">
+                        <div id="ctl00_PlaceHolderMain_PageContent_label" style="display:none">Page Content</div><div id="ctl00_PlaceHolderMain_PageContent__ControlWrapper_RichHtmlField" class="ms-rtestate-field" style="display:inline" aria-labelledby="ctl00_PlaceHolderMain_PageContent_label">
   <div id="container">
     <div class="header">
       <div><h1 class="ms-rteElement-H1"><span>Public Meetings</span></h1></div></div>
 <div class="content"><div class="col-left">
-        <p class="ms-rteElement-P" style="font-size&#58;1em;">
+        <p class="ms-rteElement-P" style="font-size:1em;">
           <span>
-            <span>Public meetings commence at 11&#58;00 AM in Room 117 of PLCB Headquarters in the Northwest Office Building in Harrisburg, PA. <br><br>Here is the upcoming meeting schedule&#58;</span></span></p></div></div></div>
-<blockquote style="border&#58;currentcolor;padding-top&#58;0px;padding-right&#58;0px;padding-left&#58;0px;margin-bottom&#58;0px;margin-left&#58;40px;"><font color="#000000">- Wednesday, February 13, 2019<br>- Wednesday, February 27, 2019<br>- Wednesday, March 13, 2019<br>-&#160;Tuesday, March 26, 2019<br>- Wednesday, April 17, 2019<br>- Wednesday, May 1, 2019<br>- Wednesday, May 15, 2019<br>- Wednesday, June 5, 2019<br>- Wednesday, June 26, 2019<br>- Wednesday, July 17, 2019<br>- Wednesday, July 31, 2019<br>- Wednesday, August 21, 2019<br>- Wednesday, September 11, 2019<br>- Wednesday, September 25, 2019<br>- Wednesday, October 9, 2019<br>- Wednesday, October 23, 2019<br>- Wednesday, November 13, 2019<br>- Wednesday, December 4, 2019<br>- Wednesday, December 18, 2019</font></blockquote>
-<blockquote style="border&#58;currentcolor;padding-top&#58;0px;padding-right&#58;0px;padding-left&#58;0px;margin-bottom&#58;0px;margin-left&#58;40px;"><span style="font-size&#58;inherit;">&#160;</span><span style="font-size&#58;inherit;">&#160;</span><br><div class="ms-rtestate-read ms-rte-wpbox"><div class="ms-rtestate-notify  ms-rtestate-read b385e5b0-48cb-4981-a437-1a7a9755faea" id="div_b385e5b0-48cb-4981-a437-1a7a9755faea" unselectable="on"><div id="MSOZoneCell_WebPartWPQ2" class="s4-wpcell ms-webpartzone-cell ms-webpart-cell-vertical ms-fullWidth " onkeyup="WpKeyUp(event)" onmouseup="WpClick(event)">
+            <span>Public meetings commence at 11:00 AM in Room 117 of PLCB Headquarters in the Northwest Office Building in Harrisburg, PA. <br><br>Here is the upcoming meeting schedule:</span></span></p></div></div></div>
+<blockquote style="border:currentcolor;padding-top:0px;padding-right:0px;padding-left:0px;margin-bottom:0px;margin-left:40px;"><font class="ms-rteThemeForeColor-2-0">- Wednesday,&nbsp;February 12, 2020<br>- Wednesday,&nbsp;February 26, 2020<br>- Wednesday, March 11, 2020<br>- Wednesday, March 25, 2020<br>- Wednesday, April 15, 2020<br>- Wednesday, April 29, 2020<br>- Wednesday, May 13, 2020<br><span aria-hidden="true"></span>- Wednesday, June 3, 2020<br>- Wednesday, June 24, 2020<br>- Wednesday, July 15, 2020<br>- Wednesday, August 5, 2020<br><span aria-hidden="true"></span>- Wednesday, August 19, 2020<br>- Wednesday, September 2, 2020<br>- Wednesday, September 23, 2020<br>- Wednesday, October 7, 2020<br><span aria-hidden="true"></span>- Wednesday, October 28, 2020<br>- Wednesday, November 18, 2020<br>- Wednesday, December 2, 2020<br>- Wednesday, December 16, 2020</font></blockquote>
+<blockquote style="border:currentcolor;padding-top:0px;padding-right:0px;padding-left:0px;margin-bottom:0px;margin-left:40px;"><span style="font-size:inherit;">&nbsp;</span><span style="font-size:inherit;">&nbsp;</span><br><div class="ms-rtestate-read ms-rte-wpbox"><div class="ms-rtestate-notify  ms-rtestate-read b385e5b0-48cb-4981-a437-1a7a9755faea" id="div_b385e5b0-48cb-4981-a437-1a7a9755faea" unselectable="on"><div id="MSOZoneCell_WebPartWPQ4" class="s4-wpcell ms-webpartzone-cell ms-webpart-cell-vertical ms-fullWidth " onkeyup="WpKeyUp(event)" onmouseup="WpClick(event)">
 		<div class="ms-webpart-chrome ms-webpart-chrome-vertical ms-webpart-chrome-fullWidth ">
-	<div class="ms-webpart-chrome-title" id="WebPartWPQ2_ChromeTitle">
-		<span title="Current Year Board Agendas and Meeting Minutes" id="WebPartTitleWPQ2" class="js-webpart-titleCell"><h2 style="text-align:justify;" class="ms-webpart-titleText"><a accesskey="W" href="/About-Us/Board/Current%20Year%20Board%20Agendas%20and%20Meeting%20Minutes"><nobr><span>Current Year Board Agendas and Meeting Minutes</span><span id="WebPartCaptionWPQ2"></span></nobr></a></h2></span>
-	</div><div WebPartID="b2f22707-7334-4e25-8162-32199003bea3" WebPartID2="b385e5b0-48cb-4981-a437-1a7a9755faea" HasPers="false" id="WebPartWPQ2" width="100%" class="ms-wpContentDivSpace " allowRemove="false" allowDelete="false" allowExport="false" style="" ><table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tr><td id="scriptWPQ2"></td></tr></table><div id="scriptPagingWPQ2" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"></div><div class="ms-clear"></div></div>
+	<div class="ms-webpart-chrome-title" id="WebPartWPQ4_ChromeTitle">
+		<span title="Current Year Board Agendas and Meeting Minutes" id="WebPartTitleWPQ4" class="js-webpart-titleCell"><h2 style="text-align:justify;" class="ms-webpart-titleText"><a accesskey="W" href="https://www.lcb.pa.gov/About-Us/Board/Current%20Year%20Board%20Agendas%20and%20Meeting%20Minutes"><nobr><span>Current Year Board Agendas and Meeting Minutes</span><span id="WebPartCaptionWPQ4"></span></nobr></a></h2></span>
+	</div><div webpartid="b2f22707-7334-4e25-8162-32199003bea3" webpartid2="b385e5b0-48cb-4981-a437-1a7a9755faea" haspers="false" id="WebPartWPQ4" width="100%" class="ms-wpContentDivSpace " allowremove="false" allowdelete="false" allowexport="false" style=""><table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tbody><tr><td id="scriptWPQ4"><div></div><iframe src="javascript:false;" id="FilterIframe429" name="FilterIframe429" style="display:none" height="0" width="0" filterlink="?" src="./PLCB Public Meetings_files/saved_resource.html"></iframe><table onmousedown="return OnTableMouseDown(event);" summary="Current Year Board Agendas and Meeting Minutes" xmlns:o="urn:schemas-microsoft-com:office:office" o:webquerysourcehref="&amp;XMLDATA=1&amp;RowLimit=0&amp;View=%7BB2F22707%2D7334%2D4E25%2D8162%2D32199003BEA3%7D" border="0" cellspacing="0" dir="none" onmouseover="EnsureSelectionHandler(event,this,429)" cellpadding="1" id="onetidDoclibViewTbl0" class="ms-listviewtable"><thead id="js-listviewthead-WPQ4"><tr valign="top" class="ms-viewheadertr ms-vhltr"><th class="ms-vh-icon ms-minWidthHeader" scope="col" onmouseover="OnChildColumn(this)"><div sortable="" sortdisable="" filterdisable="" filterable="" filterdisablemessage="" name="DocIcon" ctxnum="429" displayname="Type" fieldtype="Computed" resulttype="" sortfields="View={b2f22707-7334-4e25-8162-32199003bea3}&amp;SortField=DocIcon&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort429DocIcon" onfocus="OnFocusFilter(this)" href="javascript: " sortingfields="View={b2f22707-7334-4e25-8162-32199003bea3}&amp;SortField=DocIcon&amp;SortDir=Asc Title=" click="" to="" sort="" column"=""><img border="0" width="16" height="16" src="./PLCB Public Meetings_files/icgen.gif"></a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan429DocIcon" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan429DocIcon" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th><th scope="col" onmouseover="OnChildColumn(this)" style="max-width: 500px;" class="ms-vh2" onmousedown="ListHeaderMenu_OnMouseDown(this);"><div sortable="" sortdisable="" filterdisable="" filterable="FALSE" filterdisablemessage="" name="LinkFilename" ctxnum="429" displayname="Name" fieldtype="Computed" resulttype="" sortfields="View={b2f22707-7334-4e25-8162-32199003bea3}&amp;SortField=LinkFilename&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort429LinkFilename" onfocus="OnFocusFilter(this)" onclick="javascript: var pointerType = this.getAttribute(&#39;pointerType&#39;); if (pointerType != null &amp;&amp; typeof MSPointerEvent != &#39;undefined&#39; &amp;&amp; Number(pointerType) != MSPointerEvent.MSPOINTER_TYPE_MOUSE) { ListHeaderTouchHandler(event); return false; } return OnClickFilter(this, event);" href="javascript: " sortingfields="View={b2f22707-7334-4e25-8162-32199003bea3}&amp;SortField=LinkFilename&amp;SortDir=Asc Title=" click="" to="" sort="" column"="">Name</a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan429LinkFilename" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan429LinkFilename" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th></tr></thead><script id="scriptBodyWPQ4"></script><tbody><tr class=" ms-itmHoverEnabled " iid="429,148,0" id="429,148,0"><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="January 29, 2020.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="0" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb ms-tableCell ms-list-TitleLink itx" ctxname="ctx429" id="148" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Current%20Year%20Board%20Agendas%20and%20Meeting%20Minutes/January%2029,%202020.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="January 29, 2020, pdf File" dragid="1" draggable="true">January 29, 2020</a></div><div class="ms-list-itemLink ms-tableCell ms-alignRight " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;148&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx429_148_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="January 29, 2020.pdf Open Menu"></a></div></td></tr><tr class="ms-alternating  ms-itmHoverEnabled " iid="429,147,0" id="429,147,0"><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="January 15, 2020.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="2" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb ms-tableCell ms-list-TitleLink itx" ctxname="ctx429" id="147" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Current%20Year%20Board%20Agendas%20and%20Meeting%20Minutes/January%2015,%202020.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="January 15, 2020, pdf File" dragid="3" draggable="true">January 15, 2020</a></div><div class="ms-list-itemLink ms-tableCell ms-alignRight " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;147&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx429_147_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="January 15, 2020.pdf Open Menu"></a></div></td></tr></tbody></table></td></tr></tbody></table><div id="scriptPagingWPQ4" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><table border="0" cellpadding="0" cellspacing="0" class="ms-bottompaging" id="bottomPaging"><tbody><tr><td><div id="inplaceSearchDiv_WPQ4_lsstatus"></div></td></tr></tbody></table></div><div class="ms-clear"></div></div>
 </div>
 	</div></div>
-<div id="vid_b385e5b0-48cb-4981-a437-1a7a9755faea" unselectable="on" style="display&#58;none;"></div></div>
+<div id="vid_b385e5b0-48cb-4981-a437-1a7a9755faea" unselectable="on" style="display:none;"></div></div>
 
 
 
@@ -609,7 +626,7 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
 
 </blockquote>
 <div><div class="content"><div class="col-left">
-<a href="/About-Us/Board/Documents/March%2022,%202017.pdf">
+<a href="https://www.lcb.pa.gov/About-Us/Board/Documents/March%2022,%202017.pdf">
 
 
 
@@ -672,25 +689,25 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
                             <div id="MidRightZone" class="AspNet-WebPartZone-Vertical">
 
 						<div class="AspNet-WebPart">
-							<div class="ms-rtestate-field"><h3 class="ms-rteElement-H3B">​Archived Meeting&#160;Minutes</h3>
-<blockquote style="margin: 0px 0px 0px 40px; padding: 0px; border: currentcolor;"><p class="ms-rteElement-P" style="font-size: 1em;"><span style="color: #2a578d;"><a href="/About-Us/Board/Pages/2018-Meeting-Minutes.aspx"><span style="color: #2a578d; text-decoration: underline;"><font style="text-decoration: underline;">2018 Meeting Minutes</font></span></a></span></p><p class="ms-rteElement-P" style="font-size: 1em;"><a href="/About-Us/Board/Pages/2017-Meeting-Minutes.aspx">2017 Meeting Minutes</a></p>
+							<div class="ms-rtestate-field"><h3 class="ms-rteElement-H3B">​Archived Meeting&nbsp;Minutes</h3>
+<blockquote style="margin: 0px 0px 0px 40px; padding: 0px; border: currentcolor;"><p class="ms-rteElement-P" style="font-size: 1em;"><span style="color: #2a578d;"><span style="color: #2a578d;"><span aria-hidden="true"><span aria-hidden="true"></span><span style="color: #2a578d;"><span aria-hidden="true"><span aria-hidden="true"></span><a href="https://www.lcb.pa.gov/About-Us/Board/Pages/2019-Meeting-Minutes.aspx"><span class="ms-rteThemeForeColor-5-4" style="text-decoration: underline;"><font style="text-decoration: underline;"><span aria-hidden="true"></span>2019 Meeting Minutes<span aria-hidden="true"></span></font></span></a><span class="ms-rteThemeForeColor-5-4" aria-hidden="true"></span></span></span><span class="ms-rteThemeForeColor-5-4" aria-hidden="true"></span></span></span></span></p><p class="ms-rteElement-P" style="font-size: 1em;"><span class="ms-rteThemeForeColor-5-4"><a href="https://www.lcb.pa.gov/About-Us/Board/Pages/2018-Meeting-Minutes.aspx"><span class="ms-rteThemeForeColor-5-4" style="text-decoration: underline;"><font style="text-decoration: underline;">2018 Meeting Minutes</font></span></a></span></p><p class="ms-rteElement-P" style="font-size: 1em;"><a href="https://www.lcb.pa.gov/About-Us/Board/Pages/2017-Meeting-Minutes.aspx"><span class="ms-rteThemeForeColor-5-4" style="text-decoration: underline;">2017 Meeting Minutes</span></a></p>
 <div class="ms-rtestate-read ms-rte-wpbox" contenteditable="false"><div class="ms-rtestate-notify  ms-rtestate-read 7d961d0f-ebea-4583-b8b6-803190778a68" id="div_7d961d0f-ebea-4583-b8b6-803190778a68" unselectable="on"></div>
 <div id="vid_7d961d0f-ebea-4583-b8b6-803190778a68" style="display: none;"></div></div>
 
 <div class="ms-rtestate-read ms-rte-wpbox" contenteditable="false"><div class="ms-rtestate-notify  ms-rtestate-read 864e8f87-4c23-44e9-a051-7c838a2654ab" id="div_864e8f87-4c23-44e9-a051-7c838a2654ab" unselectable="on"></div>
 <div id="vid_864e8f87-4c23-44e9-a051-7c838a2654ab" style="display: none;"></div></div>
 
-<p class="ms-rteElement-P" style="font-size: 1em;"><a href="/About-Us/Board/Pages/2016-Meeting-Minutes.aspx">2016 Meeting Minutes</a></p>
-<p class="ms-rteElement-P" style="font-size: 1em;"><a href="/About-Us/Board/Pages/2015MeetingMinutes.aspx">2015 Meeting Minutes</a></p>
-<p class="ms-rteElement-P" style="font-size: 1em;"><a href="/About-Us/Board/Pages/2014MeetingMinutes.aspx">2014 Meeting Minutes</a></p>
-<p class="ms-rteElement-P" style="font-size: 1em;"><a href="/About-Us/Board/Pages/2013MeetingMinutes.aspx">2013 Meeting Minutes</a><br/><br/></p></blockquote>
-<p class="ms-rteElement-P" style="font-size: 1em;">&#160;</p>
+<p class="ms-rteElement-P" style="font-size: 1em;"><a href="https://www.lcb.pa.gov/About-Us/Board/Pages/2016-Meeting-Minutes.aspx"><span class="ms-rteThemeForeColor-5-4" style="text-decoration: underline;">2016 Meeting Minutes</span></a></p>
+<p class="ms-rteElement-P" style="font-size: 1em;"><a href="https://www.lcb.pa.gov/About-Us/Board/Pages/2015MeetingMinutes.aspx"><span class="ms-rteThemeForeColor-5-4" style="text-decoration: underline;">2015 Meeting Minutes</span></a></p>
+<p class="ms-rteElement-P" style="font-size: 1em;"><a href="https://www.lcb.pa.gov/About-Us/Board/Pages/2014MeetingMinutes.aspx"><span class="ms-rteThemeForeColor-5-4" style="text-decoration: underline;">2014 Meeting Minutes</span></a></p>
+<p class="ms-rteElement-P" style="font-size: 1em;"><a href="https://www.lcb.pa.gov/About-Us/Board/Pages/2013MeetingMinutes.aspx"><span class="ms-rteThemeForeColor-5-4" style="text-decoration: underline;">2013 Meeting Minutes</span></a><br><br></p></blockquote>
+<p class="ms-rteElement-P" style="font-size: 1em;">&nbsp;</p>
 <p class="ms-rteElement-P" style="font-size: 1em;">
-&#160;</p>
+&nbsp;</p>
 
 <p class="ms-rteElement-P" style="font-size: 1em;">
-&#160;</p>
-<p class="ms-rteElement-P" style="font-size: 1em;">&#160;</p></div>
+&nbsp;</p>
+<p class="ms-rteElement-P" style="font-size: 1em;">&nbsp;</p></div>
 						</div>
 						</div>
 					
@@ -704,16 +721,16 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
         <!--/row main -->
     </div>
     <!--/content-container -->
-    <div style='display:none' id='hidZone'><div id="wpz" class="AspNet-WebPartZone-Vertical">
+    <div style="display:none" id="hidZone"><div id="wpz" class="AspNet-WebPartZone-Vertical">
 
 								<div class="AspNet-WebPart">
-									<span></span><table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tr><td id="scriptWPQ4"></td></tr></table><div id="scriptPagingWPQ4" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"></div>
+									<span></span><table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tbody><tr><td id="scriptWPQ3"><div></div><iframe src="javascript:false;" id="FilterIframe428" name="FilterIframe428" style="display:none" height="0" width="0" filterlink="?" src="./PLCB Public Meetings_files/saved_resource(1).html"></iframe><table onmousedown="return OnTableMouseDown(event);" summary="2017 Meeting Minutes" xmlns:o="urn:schemas-microsoft-com:office:office" o:webquerysourcehref="&amp;XMLDATA=1&amp;RowLimit=0&amp;View=%7B6B982743%2DACEB%2D457F%2D96B7%2DD1E33DA995EB%7D" border="0" cellspacing="0" dir="none" onmouseover="EnsureSelectionHandler(event,this,428)" cellpadding="1" id="onetidDoclibViewTbl0" class="ms-listviewtable"><thead id="js-listviewthead-WPQ3"><tr valign="top" class="ms-viewheadertr ms-vhltr"><th class="ms-headerCellStyleIcon ms-vh-icon ms-vh-selectAllIcon" scope="col"><span class="ms-selectall-span" tabindex="0" role="checkbox" onfocus="EnsureSelectionHandlerOnFocus(event,this,428);" id="cbxSelectAllItems428" title="Select or deselect all items"><span tabindex="-1" class="ms-selectall-iconouter"><img class="ms-selectall-icon" alt="Select or deselect all items" src="./PLCB Public Meetings_files/spcommon.png"></span></span></th><th class="ms-vh-icon ms-minWidthHeader" scope="col" onmouseover="OnChildColumn(this)"><div sortable="" sortdisable="" filterdisable="" filterable="" filterdisablemessage="" name="DocIcon" ctxnum="428" displayname="Type" fieldtype="Computed" resulttype="" sortfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=DocIcon&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort428DocIcon" onfocus="OnFocusFilter(this)" href="javascript: " sortingfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=DocIcon&amp;SortDir=Asc Title=" click="" to="" sort="" column"=""><img border="0" width="16" height="16" src="./PLCB Public Meetings_files/icgen.gif"></a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan428DocIcon" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan428DocIcon" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th><th scope="col" onmouseover="OnChildColumn(this)" style="max-width: 500px;" class="ms-vh2" onmousedown="ListHeaderMenu_OnMouseDown(this);"><div sortable="" sortdisable="" filterdisable="" filterable="FALSE" filterdisablemessage="" name="LinkFilename" ctxnum="428" displayname="Name" fieldtype="Computed" resulttype="" sortfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=LinkFilename&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort428LinkFilename" onfocus="OnFocusFilter(this)" onclick="javascript: var pointerType = this.getAttribute(&#39;pointerType&#39;); if (pointerType != null &amp;&amp; typeof MSPointerEvent != &#39;undefined&#39; &amp;&amp; Number(pointerType) != MSPointerEvent.MSPOINTER_TYPE_MOUSE) { ListHeaderTouchHandler(event); return false; } return OnClickFilter(this, event);" href="javascript: " sortingfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=LinkFilename&amp;SortDir=Asc Title=" click="" to="" sort="" column"="">Name</a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan428LinkFilename" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan428LinkFilename" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th><th aria-label="Open Menu"></th><th class="ms-vh2" scope="col" onmouseover="OnChildColumn(this)" onmousedown="ListHeaderMenu_OnMouseDown(this);"><div sortable="" sortdisable="" filterdisable="" filterable="" filterdisablemessage="" name="Modified" ctxnum="428" displayname="Modified" fieldtype="DateTime" resulttype="" sortfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=Modified&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort428Modified" onfocus="OnFocusFilter(this)" onclick="javascript: var pointerType = this.getAttribute(&#39;pointerType&#39;); if (pointerType != null &amp;&amp; typeof MSPointerEvent != &#39;undefined&#39; &amp;&amp; Number(pointerType) != MSPointerEvent.MSPOINTER_TYPE_MOUSE) { ListHeaderTouchHandler(event); return false; } return OnClickFilter(this, event);" href="javascript: " sortingfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=Modified&amp;SortDir=Asc Title=" click="" to="" sort="" column"="">Modified</a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan428Modified" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan428Modified" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th><th scope="col" onmouseover="OnChildColumn(this)" style="max-width: 500px;" class="ms-vh2" onmousedown="ListHeaderMenu_OnMouseDown(this);"><div sortable="" sortdisable="" filterdisable="" filterable="" filterdisablemessage="" name="Editor" ctxnum="428" displayname="Modified By" fieldtype="User" resulttype="" sortfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=Editor&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort428Editor" onfocus="OnFocusFilter(this)" onclick="javascript: var pointerType = this.getAttribute(&#39;pointerType&#39;); if (pointerType != null &amp;&amp; typeof MSPointerEvent != &#39;undefined&#39; &amp;&amp; Number(pointerType) != MSPointerEvent.MSPOINTER_TYPE_MOUSE) { ListHeaderTouchHandler(event); return false; } return OnClickFilter(this, event);" href="javascript: " sortingfields="View={6b982743-aceb-457f-96b7-d1e33da995eb}&amp;SortField=Editor&amp;SortDir=Asc Title=" click="" to="" sort="" column"="">Modified By</a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan428Editor" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan428Editor" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th></tr></thead><script id="scriptBodyWPQ3"></script><tbody><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,96,0" id="428,96,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="April 19, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="4" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="96" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/April%2019,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="April 19, 2017, pdf File" dragid="5" draggable="true">April 19, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;96&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_96_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="April 19, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="5/3/2017 12:15 PM">May 3, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,95,0" id="428,95,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="April 5, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="6" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="95" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/April%205,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="April 5, 2017, pdf File" dragid="7" draggable="true">April 5, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;95&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_95_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="April 5, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="4/19/2017 2:39 PM">April 19, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,102,0" id="428,102,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="August 2, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="8" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="102" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/August%202,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="August 2, 2017, pdf File" dragid="9" draggable="true">August 2, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;102&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_102_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="August 2, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="8/23/2017 11:55 AM">August 23, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,103,0" id="428,103,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="August 23, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="10" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="103" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/August%2023,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="August 23, 2017, pdf File" dragid="11" draggable="true">August 23, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;103&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_103_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="August 23, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="9/13/2017 12:19 PM">September 13, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,111,0" id="428,111,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="December 20, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="12" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="111" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/December%2020,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="December 20, 2017, pdf File" dragid="13" draggable="true">December 20, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;111&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_111_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="December 20, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="1/17/2018 12:06 PM">January 17, 2018</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,110,0" id="428,110,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="December 6, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="14" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="110" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/December%206,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="December 6, 2017, pdf File" dragid="15" draggable="true">December 6, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;110&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_110_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="December 6, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="12/20/2017 11:29 AM">December 20, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,91,0" id="428,91,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="February 1, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="16" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="91" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/February%201,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="February 1, 2017, pdf File" dragid="17" draggable="true">February 1, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;91&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_91_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="February 1, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="2/15/2017 12:00 PM">February 15, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,92,0" id="428,92,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="February 15, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="18" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="92" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/February%2015,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="February 15, 2017, pdf File" dragid="19" draggable="true">February 15, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;92&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_92_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="February 15, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="3/8/2017 11:33 AM">March 8, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,90,0" id="428,90,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="January 18, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="20" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="90" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/January%2018,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="January 18, 2017, pdf File" dragid="21" draggable="true">January 18, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;90&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_90_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="January 18, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="2/1/2017 12:00 PM">February 1, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,101,0" id="428,101,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="July 19, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="22" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="101" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/July%2019,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="July 19, 2017, pdf File" dragid="23" draggable="true">July 19, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;101&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_101_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="July 19, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="8/2/2017 11:58 AM">August 2, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,100,0" id="428,100,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="June 28, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="24" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="100" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/June%2028,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="June 28, 2017, pdf File" dragid="25" draggable="true">June 28, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;100&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_100_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="June 28, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="7/19/2017 11:38 AM">July 19, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,99,0" id="428,99,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="June 7, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="26" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="99" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/June%207,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="June 7, 2017, pdf File" dragid="27" draggable="true">June 7, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;99&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_99_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="June 7, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="6/28/2017 11:38 AM">June 28, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,94,0" id="428,94,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="March 22, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="28" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="94" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/March%2022,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="March 22, 2017, pdf File" dragid="29" draggable="true">March 22, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;94&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_94_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="March 22, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="4/5/2017 11:48 AM">April 5, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,98,0" id="428,98,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="May 17, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="30" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="98" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/May%2017,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="May 17, 2017, pdf File" dragid="31" draggable="true">May 17, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;98&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_98_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="May 17, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="6/7/2017 12:02 PM">June 7, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,97,0" id="428,97,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="May 3, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="32" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="97" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/May%203,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="May 3, 2017, pdf File" dragid="33" draggable="true">May 3, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;97&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_97_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="May 3, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="5/17/2017 12:05 PM">May 17, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,108,0" id="428,108,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="November 1, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="34" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="108" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/November%201,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="November 1, 2017, pdf File" dragid="35" draggable="true">November 1, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;108&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_108_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="November 1, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="11/15/2017 12:48 PM">November 15, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,109,0" id="428,109,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="November 15, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="36" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="109" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/November%2015,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="November 15, 2017, pdf File" dragid="37" draggable="true">November 15, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;109&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_109_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="November 15, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="12/6/2017 12:02 PM">December 6, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,106,0" id="428,106,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="October 11, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="38" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="106" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/October%2011,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="October 11, 2017, pdf File" dragid="39" draggable="true">October 11, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;106&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_106_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="October 11, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="10/23/2017 9:43 AM">October 23, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,107,0" id="428,107,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="October 20, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="40" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="107" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/October%2020,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="October 20, 2017, pdf File" dragid="41" draggable="true">October 20, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;107&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_107_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="October 20, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="11/1/2017 12:32 PM">November 1, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,104,0" id="428,104,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="September 13, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="42" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="104" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/September%2013,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="September 13, 2017, pdf File" dragid="43" draggable="true">September 13, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;104&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_104_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="September 13, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="9/27/2017 11:48 AM">September 27, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="428,105,0" id="428,105,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="September 27, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="44" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx428" id="105" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/September%2027,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="September 27, 2017, pdf File" dragid="45" draggable="true">September 27, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;105&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx428_105_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="September 27, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="10/11/2017 11:39 AM">October 11, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr></tbody></table></td></tr></tbody></table><div id="scriptPagingWPQ3" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><table border="0" cellpadding="0" cellspacing="0" class="ms-bottompaging" id="bottomPaging"><tbody><tr><td><div id="inplaceSearchDiv_WPQ3_lsstatus"></div></td></tr></tbody></table></div>
 								</div>
 									<div class="AspNet-WebPart">
-										<span></span><table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tr><td id="scriptWPQ3"></td></tr></table><div id="scriptPagingWPQ3" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"></div>
+										<span></span><table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tbody><tr><td id="scriptWPQ2"><div></div><iframe src="javascript:false;" id="FilterIframe427" name="FilterIframe427" style="display:none" height="0" width="0" filterlink="?" src="./PLCB Public Meetings_files/saved_resource(2).html"></iframe><table onmousedown="return OnTableMouseDown(event);" summary="2017 Meeting Minutes" xmlns:o="urn:schemas-microsoft-com:office:office" o:webquerysourcehref="&amp;XMLDATA=1&amp;RowLimit=0&amp;View=%7BB1692D68%2D0638%2D405B%2DB4FD%2D3A8C40498E30%7D" border="0" cellspacing="0" dir="none" onmouseover="EnsureSelectionHandler(event,this,427)" cellpadding="1" id="onetidDoclibViewTbl0" class="ms-listviewtable"><thead id="js-listviewthead-WPQ2"><tr valign="top" class="ms-viewheadertr ms-vhltr"><th class="ms-headerCellStyleIcon ms-vh-icon ms-vh-selectAllIcon" scope="col"><span class="ms-selectall-span" tabindex="0" role="checkbox" onfocus="EnsureSelectionHandlerOnFocus(event,this,427);" id="cbxSelectAllItems427" title="Select or deselect all items"><span tabindex="-1" class="ms-selectall-iconouter"><img class="ms-selectall-icon" alt="Select or deselect all items" src="./PLCB Public Meetings_files/spcommon.png"></span></span></th><th class="ms-vh-icon ms-minWidthHeader" scope="col" onmouseover="OnChildColumn(this)"><div sortable="" sortdisable="" filterdisable="" filterable="" filterdisablemessage="" name="DocIcon" ctxnum="427" displayname="Type" fieldtype="Computed" resulttype="" sortfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=DocIcon&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort427DocIcon" onfocus="OnFocusFilter(this)" href="javascript: " sortingfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=DocIcon&amp;SortDir=Asc Title=" click="" to="" sort="" column"=""><img border="0" width="16" height="16" src="./PLCB Public Meetings_files/icgen.gif"></a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan427DocIcon" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan427DocIcon" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th><th scope="col" onmouseover="OnChildColumn(this)" style="max-width: 500px;" class="ms-vh2" onmousedown="ListHeaderMenu_OnMouseDown(this);"><div sortable="" sortdisable="" filterdisable="" filterable="FALSE" filterdisablemessage="" name="LinkFilename" ctxnum="427" displayname="Name" fieldtype="Computed" resulttype="" sortfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=LinkFilename&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort427LinkFilename" onfocus="OnFocusFilter(this)" onclick="javascript: var pointerType = this.getAttribute(&#39;pointerType&#39;); if (pointerType != null &amp;&amp; typeof MSPointerEvent != &#39;undefined&#39; &amp;&amp; Number(pointerType) != MSPointerEvent.MSPOINTER_TYPE_MOUSE) { ListHeaderTouchHandler(event); return false; } return OnClickFilter(this, event);" href="javascript: " sortingfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=LinkFilename&amp;SortDir=Asc Title=" click="" to="" sort="" column"="">Name</a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan427LinkFilename" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan427LinkFilename" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th><th aria-label="Open Menu"></th><th class="ms-vh2" scope="col" onmouseover="OnChildColumn(this)" onmousedown="ListHeaderMenu_OnMouseDown(this);"><div sortable="" sortdisable="" filterdisable="" filterable="" filterdisablemessage="" name="Modified" ctxnum="427" displayname="Modified" fieldtype="DateTime" resulttype="" sortfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=Modified&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort427Modified" onfocus="OnFocusFilter(this)" onclick="javascript: var pointerType = this.getAttribute(&#39;pointerType&#39;); if (pointerType != null &amp;&amp; typeof MSPointerEvent != &#39;undefined&#39; &amp;&amp; Number(pointerType) != MSPointerEvent.MSPOINTER_TYPE_MOUSE) { ListHeaderTouchHandler(event); return false; } return OnClickFilter(this, event);" href="javascript: " sortingfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=Modified&amp;SortDir=Asc Title=" click="" to="" sort="" column"="">Modified</a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan427Modified" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan427Modified" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th><th scope="col" onmouseover="OnChildColumn(this)" style="max-width: 500px;" class="ms-vh2" onmousedown="ListHeaderMenu_OnMouseDown(this);"><div sortable="" sortdisable="" filterdisable="" filterable="" filterdisablemessage="" name="Editor" ctxnum="427" displayname="Modified By" fieldtype="User" resulttype="" sortfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=Editor&amp;SortDir=Asc" class="ms-vh-div"><a class="ms-headerSortTitleLink" id="diidSort427Editor" onfocus="OnFocusFilter(this)" onclick="javascript: var pointerType = this.getAttribute(&#39;pointerType&#39;); if (pointerType != null &amp;&amp; typeof MSPointerEvent != &#39;undefined&#39; &amp;&amp; Number(pointerType) != MSPointerEvent.MSPOINTER_TYPE_MOUSE) { ListHeaderTouchHandler(event); return false; } return OnClickFilter(this, event);" href="javascript: " sortingfields="View={b1692d68-0638-405b-b4fd-3a8c40498e30}&amp;SortField=Editor&amp;SortDir=Asc Title=" click="" to="" sort="" column"="">Modified By</a><span class="ms-sortarrowdown-iconouter" id="diidSortArrowSpan427Editor" style="display: none;"><img class="ms-sortarrowdown-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span><span class="ms-filter-iconouter" id="diidFilterSpan427Editor" style="display: none;"><img class="ms-filter-icon" src="./PLCB Public Meetings_files/spcommon.png" alt=""></span></div><div class="ms-positionRelative"><div class="s4-ctx"><span> </span><a onfocus="OnChildColumn(this.parentNode.parentNode.parentNode); return false;" class="ms-headerSortArrowLink" onclick="PopMenuFromChevron(event); return false;" href="javascript:;" title="Open Menu"><img style="visibility: hidden;" src="./PLCB Public Meetings_files/ecbarw.png" alt="" +="" stshtmlencode(strings.sts.l_openmenu)="" ""="" ms-jsgrid-click-passthrough="true"></a><span> </span></div></div></th></tr></thead><script id="scriptBodyWPQ2"></script><tbody><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,96,0" id="427,96,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="April 19, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="46" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="96" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/April%2019,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="April 19, 2017, pdf File" dragid="47" draggable="true">April 19, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;96&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_96_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="April 19, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="5/3/2017 12:15 PM">May 3, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,95,0" id="427,95,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="April 5, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="48" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="95" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/April%205,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="April 5, 2017, pdf File" dragid="49" draggable="true">April 5, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;95&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_95_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="April 5, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="4/19/2017 2:39 PM">April 19, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,102,0" id="427,102,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="August 2, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="50" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="102" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/August%202,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="August 2, 2017, pdf File" dragid="51" draggable="true">August 2, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;102&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_102_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="August 2, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="8/23/2017 11:55 AM">August 23, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,103,0" id="427,103,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="August 23, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="52" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="103" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/August%2023,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="August 23, 2017, pdf File" dragid="53" draggable="true">August 23, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;103&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_103_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="August 23, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="9/13/2017 12:19 PM">September 13, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,111,0" id="427,111,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="December 20, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="54" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="111" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/December%2020,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="December 20, 2017, pdf File" dragid="55" draggable="true">December 20, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;111&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_111_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="December 20, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="1/17/2018 12:06 PM">January 17, 2018</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,110,0" id="427,110,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="December 6, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="56" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="110" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/December%206,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="December 6, 2017, pdf File" dragid="57" draggable="true">December 6, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;110&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_110_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="December 6, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="12/20/2017 11:29 AM">December 20, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,91,0" id="427,91,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="February 1, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="58" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="91" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/February%201,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="February 1, 2017, pdf File" dragid="59" draggable="true">February 1, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;91&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_91_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="February 1, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="2/15/2017 12:00 PM">February 15, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,92,0" id="427,92,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="February 15, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="60" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="92" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/February%2015,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="February 15, 2017, pdf File" dragid="61" draggable="true">February 15, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;92&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_92_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="February 15, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="3/8/2017 11:33 AM">March 8, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,90,0" id="427,90,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="January 18, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="62" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="90" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/January%2018,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="January 18, 2017, pdf File" dragid="63" draggable="true">January 18, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;90&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_90_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="January 18, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="2/1/2017 12:00 PM">February 1, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,101,0" id="427,101,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="July 19, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="64" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="101" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/July%2019,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="July 19, 2017, pdf File" dragid="65" draggable="true">July 19, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;101&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_101_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="July 19, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="8/2/2017 11:58 AM">August 2, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,100,0" id="427,100,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="June 28, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="66" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="100" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/June%2028,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="June 28, 2017, pdf File" dragid="67" draggable="true">June 28, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;100&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_100_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="June 28, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="7/19/2017 11:38 AM">July 19, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,99,0" id="427,99,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="June 7, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="68" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="99" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/June%207,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="June 7, 2017, pdf File" dragid="69" draggable="true">June 7, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;99&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_99_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="June 7, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="6/28/2017 11:38 AM">June 28, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,94,0" id="427,94,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="March 22, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="70" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="94" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/March%2022,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="March 22, 2017, pdf File" dragid="71" draggable="true">March 22, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;94&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_94_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="March 22, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="4/5/2017 11:48 AM">April 5, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,98,0" id="427,98,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="May 17, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="72" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="98" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/May%2017,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="May 17, 2017, pdf File" dragid="73" draggable="true">May 17, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;98&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_98_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="May 17, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="6/7/2017 12:02 PM">June 7, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,97,0" id="427,97,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="May 3, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="74" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="97" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/May%203,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="May 3, 2017, pdf File" dragid="75" draggable="true">May 3, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;97&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_97_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="May 3, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="5/17/2017 12:05 PM">May 17, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,108,0" id="427,108,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="November 1, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="76" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="108" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/November%201,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="November 1, 2017, pdf File" dragid="77" draggable="true">November 1, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;108&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_108_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="November 1, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="11/15/2017 12:48 PM">November 15, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,109,0" id="427,109,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="November 15, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="78" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="109" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/November%2015,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="November 15, 2017, pdf File" dragid="79" draggable="true">November 15, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;109&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_109_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="November 15, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="12/6/2017 12:02 PM">December 6, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,106,0" id="427,106,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="October 11, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="80" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="106" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/October%2011,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="October 11, 2017, pdf File" dragid="81" draggable="true">October 11, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;106&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_106_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="October 11, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="10/23/2017 9:43 AM">October 23, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,107,0" id="427,107,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="October 20, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="82" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="107" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/October%2020,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="October 20, 2017, pdf File" dragid="83" draggable="true">October 20, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;107&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_107_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="October 20, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="11/1/2017 12:32 PM">November 1, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class="ms-alternating  ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,104,0" id="427,104,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="September 13, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="84" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="104" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/September%2013,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="September 13, 2017, pdf File" dragid="85" draggable="true">September 13, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;104&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_104_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="September 13, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="9/27/2017 11:48 AM">September 27, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr><tr class=" ms-itmHoverEnabled ms-itmhover" oncontextmenu="return ShowCallOutOrECBWrapper(this, event, true)" iid="427,105,0" id="427,105,0"><td class="ms-cellStyleNonEditable ms-vb-itmcbx ms-vb-imgFirstCell" tabindex="0"><div role="checkbox" class="s4-itm-cbx s4-itm-imgCbx" tabindex="-1" aria-checked="false"><span class="ms-accessible">Select or deselect this item</span><span class="s4-itm-imgCbx-inner"><span class="ms-selectitem-span"><img class="ms-selectitem-icon" alt="" src="./PLCB Public Meetings_files/spcommon.png"></span></span></div></td><td class="ms-cellstyle ms-vb-icon"><img width="16" height="16" border="0" alt="pdf File" title="September 27, 2017.pdf" src="./PLCB Public Meetings_files/icpdf.png" dragid="86" draggable="true" class=" ms-draggable"></td><td class="ms-cellstyle ms-vb-title" isecb="TRUE" iscallout="TRUE" height="100%"><div class="ms-vb  itx" ctxname="ctx427" id="105" app=""><a class="ms-listlink ms-draggable" href="https://www.lcb.pa.gov/About-Us/Board/Documents/September%2027,%202017.pdf" onmousedown="return VerifyHref(this,event,&#39;1&#39;,&#39;&#39;,&#39;&#39;)" onclick="return DispEx(this,event,&#39;TRUE&#39;,&#39;FALSE&#39;,&#39;FALSE&#39;,&#39;&#39;,&#39;1&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;&#39;,&#39;0&#39;,&#39;0&#39;,&#39;0x1000030041&#39;)" aria-label="September 27, 2017, pdf File" dragid="87" draggable="true">September 27, 2017</a></div></td><td class="ms-list-itemLink-td ms-cellstyle"><div class="ms-list-itemLink  " onclick="ShowMenuForTrOuter(this,event, true); return false;"><a ms-jsgrid-click-passthrough="true" class="ms-lstItmLinkAnchor ms-ellipsis-a" title="Open Menu" onclick="OpenCalloutAndSelectItem(this, event, this, &#39;105&#39;); return false;" href="https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx#" id="ctx427_105_calloutLaunchPoint"><img class="ms-ellipsis-icon" src="./PLCB Public Meetings_files/spcommon.png" alt="September 27, 2017.pdf Open Menu"></a></div></td><td class="ms-cellstyle ms-vb2"><span class="ms-noWrap" title="10/11/2017 11:39 AM">October 11, 2017</span></td><td class="ms-vb-lastCell ms-cellstyle ms-vb2"><span class="ms-verticalAlignTop ms-noWrap ms-displayInlineBlock"><span class="ms-noWrap ms-imnSpan">System Account</span></span></td></tr></tbody></table></td></tr></tbody></table><div id="scriptPagingWPQ2" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><table border="0" cellpadding="0" cellspacing="0" class="ms-bottompaging" id="bottomPaging"><tbody><tr><td><div id="inplaceSearchDiv_WPQ2_lsstatus"></div></td></tr></tbody></table></div>
 									</div>
 										<div class="AspNet-WebPart">
-											<table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tr><td id="scriptWPQ2"></td></tr></table><div id="scriptPagingWPQ2" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"></div>
+											<table width="100%" cellspacing="0" cellpadding="0" border="0" role="presentation" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"><tbody><tr><td id="scriptWPQ4"></td></tr></tbody></table><div id="scriptPagingWPQ4" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:sharepoint="Microsoft.SharePoint.WebControls" xmlns:pcm="urn:PageContentManager" xmlns:ddwrt2="urn:frontpage:internal"></div>
 										</div>
 										</div>
 									</div>
@@ -730,7 +747,7 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
         if (!((formDigestElement == null) || (formDigestElement.tagName.toLowerCase() != 'input') || (formDigestElement.type.toLowerCase() != 'hidden') ||
             (formDigestElement.value == null) || (formDigestElement.value.length <= 0)))
         {
-            formDigestElement.value = '0xEBA9FCE757887ECA9D4DA175CAFDAC842A8037A7404991FB106ADB4F4D797A6D480F747056561D7586954EA0EAEF99BC199AA6889FA42AE301A11E06F2AE003E,09 Feb 2019 01:02:41 -0000';
+            formDigestElement.value = '0xE93D5FB5CD4D8E0E8FFDF1F649E7527BE2DADCBC2676DD1CC9F6EBD359CD901D10DC2BD1DC29EE0C83F6258A641E880415CDEC7C2BECF56A956016FB4C3CB598,02 Feb 2020 03:49:38 -0000';
             g_updateFormDigestPageLoaded = new Date();
         }
         //]]>
@@ -770,50 +787,87 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
             
             <!-- Color Picker -->
             
+            <!-- Governor Goals -->
+            
+
+<div>
+    
+</div>
+
             <!-- Agency Footer -->
             
 
 <div class="primary-color back-to-top">
-    <i class="fa fa-chevron-up"></i>
+    <i class="pais pai-chevron-up"></i>
     <!-- <p>TOP</p> -->
-</div> 
+</div>
 
 <footer id="divAgencyFooter" class="upper row full-width small-12">
     <nav class="row show-for-large agency-footer-nav">
-        <div id="ctl00_ctl74_divAgencyFooterLeft" class="large-10 columns agency-footer-left">
+        <div id="ctl00_ctl76_divAgencyFooterLeft" class="large-10 columns agency-footer-left">
             <div class="row">
-                <div id="ctl00_ctl74_divLogo" class="logo-section">
+                <div id="ctl00_ctl76_divLogo" class="large-6 columns logo-section">
                     <div class="row columns">
-                        <a href="https://www.lcb.pa.gov" id="ctl00_ctl74_aAgencyImgLink">
-                            <img src="https://www.lcb.pa.gov/Style%20Library/Agency/img/logos/AgencyLogoMobile.png" id="ctl00_ctl74_imgAgencyImage" class="agency-image" alt="Agency Image" />
+                        <a href="https://www.lcb.pa.gov/" id="ctl00_ctl76_aAgencyImgLink">
+                            <img src="./PLCB Public Meetings_files/AgencyLogoMobile.png" id="ctl00_ctl76_imgAgencyImage" class="agency-image" alt="Agency Image">
                         </a>
                     </div>
-                    <div id="ctl00_ctl74_divOfficials" class="row columns officials-section">
+                    <div id="ctl00_ctl76_divOfficials" class="row columns officials-section">
                         
                     </div>
-                    <div id="ctl00_ctl74_divContactUs" class="row columns">
-                        <a id="ctl00_ctl74_lnkContactUs" class="button primary-color" href="https://www.lcb.pa.gov/About-Us/Contact/Pages/default.aspx">Contact Us</a>
+                    <div id="ctl00_ctl76_divContactUs" class="row columns">
+                        <a id="ctl00_ctl76_lnkContactUs" class="button primary-color" href="https://www.lcb.pa.gov/About-Us/Contact/Pages/default.aspx">Contact Us</a>
                     </div>
                 </div>
-                
+                <div id="ctl00_ctl76_divLinks" class="large-6 columns">
+                    
+                            <div class="row">
+                                
+                                        <div class="columns large-6 divLinks">
+                                            <span class="agency-footer-title">Join Our Team</span>
+                                            <ul class="agency-footer-sub-menu">
+                                                
+                                                        <li class="agency-footer-sub-menu-item">
+                                                            <a id="ctl00_ctl76_rptRows_ctl00_rptCats_ctl00_rptLnks_ctl00_CategoryLink" class="menu-link sub-menu-link" href="https://www.lcb.pa.gov/JoinOurTeam/Pages/Employment.aspx">Learn more about employment opportunities with the PLCB</a>
+                                                            
+                                                        </li>
+                                                    
+                                            </ul>
+                                        </div>
+                                    
+                                        <div class="columns large-6 divLinks">
+                                            <span class="agency-footer-title">Policies</span>
+                                            <ul class="agency-footer-sub-menu">
+                                                
+                                                        <li class="agency-footer-sub-menu-item">
+                                                            <a id="ctl00_ctl76_rptRows_ctl00_rptCats_ctl01_rptLnks_ctl00_CategoryLink" class="menu-link sub-menu-link" href="https://www.lcb.pa.gov/Pages/Social-Media-Terms-of-Use.aspx">Social Media</a>
+                                                            
+                                                        </li>
+                                                    
+                                            </ul>
+                                        </div>
+                                    
+                            </div>
+                        
+                </div>
             </div>
         </div>
-        <div id="ctl00_ctl74_divAgencyFooterRight" class="large-2 columns agency-footer-right">
-            <div id="ctl00_ctl74_socialMediaContainer">
+        <div id="ctl00_ctl76_divAgencyFooterRight" class="large-2 columns agency-footer-right">
+            <div id="ctl00_ctl76_socialMediaContainer">
                 
                         <span class="social-media-link">
-                            <i class='fa fa-facebook-square'></i>
-                            <a id="ctl00_ctl74_rptSocMedia_ctl00_HyperLink2" href="https://www.facebook.com/PAAlcoholEducation/">Facebook</a>
+                            <i class="paib pai-fw pai-facebook-square"></i>
+                            <a id="ctl00_ctl76_rptSocMedia_ctl00_HyperLink2" href="https://www.facebook.com/PAAlcoholEducation/">Facebook</a>
                         </span>
                     
                         <span class="social-media-link">
-                            <i class='fa fa-youtube-play'></i>
-                            <a id="ctl00_ctl74_rptSocMedia_ctl01_HyperLink2" href="https://www.youtube.com/channel/UCNDGYPGOuvy4lP3PDiLgfgQ">YouTube</a>
+                            <i class="paib pai-fw pai-youtube-square"></i>
+                            <a id="ctl00_ctl76_rptSocMedia_ctl01_HyperLink2" href="https://www.youtube.com/channel/UCNDGYPGOuvy4lP3PDiLgfgQ">YouTube</a>
                         </span>
                     
                         <span class="social-media-link">
-                            <i class='fa fa-linkedin'></i>
-                            <a id="ctl00_ctl74_rptSocMedia_ctl02_HyperLink2" href="https://www.linkedin.com/company/pennsylvania-liquor-control-board">LinkedIn</a>
+                            <i class="paib pai-fw pai-linkedin"></i>
+                            <a id="ctl00_ctl76_rptSocMedia_ctl02_HyperLink2" href="https://www.linkedin.com/company/pennsylvania-liquor-control-board" class="external" target="_blank">LinkedIn<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a>
                         </span>
                     
             </div>
@@ -821,47 +875,75 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
     </nav>
 
 
-    <div id="ctl00_ctl74_divAgencyFooterMobileMenu" class="small-12 columns hide-for-large agency-footer-mobile">
+    <div id="ctl00_ctl76_divAgencyFooterMobileMenu" class="small-12 columns hide-for-large agency-footer-mobile">
         <div class="text-center row">
             <div class="small-12">
-                <a href="https://www.lcb.pa.gov" id="ctl00_ctl74_a1">
-                    <img src="https://www.lcb.pa.gov/Style%20Library/Agency/img/logos/AgencyLogoMobile.png" id="ctl00_ctl74_mobileImage" class="agency-image" alt="Agency Image" />
+                <a href="https://www.lcb.pa.gov/" id="ctl00_ctl76_a1">
+                    <img src="./PLCB Public Meetings_files/AgencyLogoMobile.png" id="ctl00_ctl76_mobileImage" class="agency-image" alt="Agency Image">
                 </a>
             </div>
-            <div id="ctl00_ctl74_div2" class="small-12">
+            <div id="ctl00_ctl76_div2" class="small-12">
                 
             </div>
-            <div id="ctl00_ctl74_div3" class="small-12">
-                <a id="ctl00_ctl74_lnkMobileContact" class="button primary-color" href="https://www.lcb.pa.gov/About-Us/Contact/Pages/default.aspx">Contact Us</a>
+            <div id="ctl00_ctl76_div3" class="small-12">
+                <a id="ctl00_ctl76_lnkMobileContact" class="button primary-color" href="https://www.lcb.pa.gov/About-Us/Contact/Pages/default.aspx">Contact Us</a>
             </div>
         </div>
 
-        <ul class="accordion agency-accordion" data-accordion data-allow-all-closed='true'>
+        <ul class="accordion agency-accordion" data-accordion="" data-allow-all-closed="true" role="tablist" data-e="omk0fl-e">
             
+                    <li id="ctl00_ctl76_rptCategory_ctl00_accordionAgencyRow1" class="accordion-item agency-accordion-item" data-accordion-item="">
+                        <a id="ctl00_ctl76_rptCategory_ctl00_accordionAgencyRow1" class="accordion-title agency-accordion-title" href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SpEnterprise.AgencyFooter/#" aria-controls="8rpvi4-accordion" role="tab" aria-expanded="false" aria-selected="false">Join Our Team</a>
+                        <div class="accordion-content agency-accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl76_rptCategory_ctl00_accordionAgencyRow1" aria-hidden="true" id="8rpvi4-accordion">
+                            <ul id="ctl00_ctl76_rptCategory_ctl00_accordionAgencyList1" class="accordion-list agency-accordion-list">
+                                
+                                        <li class="accordian-list-item">
+                                            <a id="ctl00_ctl76_rptCategory_ctl00_rptLinks_ctl00_mobilelink" class="accordian-link" href="https://www.lcb.pa.gov/JoinOurTeam/Pages/Employment.aspx">Learn more about employment opportunities with the PLCB</a>
+                                            
+                                        </li>
+                                    
+                            </ul>
+                        </div>
+                    </li>
+                
+                    <li id="ctl00_ctl76_rptCategory_ctl01_accordionAgencyRow1" class="accordion-item agency-accordion-item" data-accordion-item="">
+                        <a id="ctl00_ctl76_rptCategory_ctl01_accordionAgencyRow1" class="accordion-title agency-accordion-title" href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SpEnterprise.AgencyFooter/#" aria-controls="1krryg-accordion" role="tab" aria-expanded="false" aria-selected="false">Policies</a>
+                        <div class="accordion-content agency-accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl76_rptCategory_ctl01_accordionAgencyRow1" aria-hidden="true" id="1krryg-accordion">
+                            <ul id="ctl00_ctl76_rptCategory_ctl01_accordionAgencyList1" class="accordion-list agency-accordion-list">
+                                
+                                        <li class="accordian-list-item">
+                                            <a id="ctl00_ctl76_rptCategory_ctl01_rptLinks_ctl00_mobilelink" class="accordian-link" href="https://www.lcb.pa.gov/Pages/Social-Media-Terms-of-Use.aspx">Social Media</a>
+                                            
+                                        </li>
+                                    
+                            </ul>
+                        </div>
+                    </li>
+                
 
-            <li id="ctl00_ctl74_mobileSocMedia" class="accordion-item agency-accordion-item" data-accordion-item="">
-                <a id="ctl00_ctl74_HyperLink3" class="accordion-title agency-accordion-title" href="../../../_CONTROLTEMPLATES/15/PA.SpEnterprise.AgencyFooter/#">Social Media</a>
-                <div class="accordion-content agency-accordion-content" data-tab-content>
-                    <ul id="ctl00_ctl74_Ul1" class="accordion-list agency-accordion-list">
+            <li id="ctl00_ctl76_mobileSocMedia" class="accordion-item agency-accordion-item" data-accordion-item="">
+                <a id="ctl00_ctl76_mobileSocMedia" class="accordion-title agency-accordion-title" href="https://www.lcb.pa.gov/_CONTROLTEMPLATES/15/PA.SpEnterprise.AgencyFooter/#" aria-controls="042uek-accordion" role="tab" aria-expanded="false" aria-selected="false">Social Media</a>
+                <div class="accordion-content agency-accordion-content" data-tab-content="" role="tabpanel" aria-labelledby="ctl00_ctl76_mobileSocMedia" aria-hidden="true" id="042uek-accordion">
+                    <ul id="ctl00_ctl76_Ul1" class="accordion-list agency-accordion-list">
                         
                                 <li>
                                     <span class="social-media-link">
-                                        <i class='fa fa-facebook-square'></i>
-                                        <a id="ctl00_ctl74_rptMobileSocMedia_ctl00_HyperLink4" href="https://www.facebook.com/PAAlcoholEducation/">Facebook</a>
+                                        <i class="paib pai-fw pai-facebook-square"></i>
+                                        <a id="ctl00_ctl76_rptMobileSocMedia_ctl00_HyperLink4" href="https://www.facebook.com/PAAlcoholEducation/">Facebook</a>
                                     </span>
                                 </li>
                             
                                 <li>
                                     <span class="social-media-link">
-                                        <i class='fa fa-youtube-play'></i>
-                                        <a id="ctl00_ctl74_rptMobileSocMedia_ctl01_HyperLink4" href="https://www.youtube.com/channel/UCNDGYPGOuvy4lP3PDiLgfgQ">YouTube</a>
+                                        <i class="paib pai-fw pai-youtube-square"></i>
+                                        <a id="ctl00_ctl76_rptMobileSocMedia_ctl01_HyperLink4" href="https://www.youtube.com/channel/UCNDGYPGOuvy4lP3PDiLgfgQ">YouTube</a>
                                     </span>
                                 </li>
                             
                                 <li>
                                     <span class="social-media-link">
-                                        <i class='fa fa-linkedin'></i>
-                                        <a id="ctl00_ctl74_rptMobileSocMedia_ctl02_HyperLink4" href="https://www.linkedin.com/company/pennsylvania-liquor-control-board">LinkedIn</a>
+                                        <i class="paib pai-fw pai-linkedin"></i>
+                                        <a id="ctl00_ctl76_rptMobileSocMedia_ctl02_HyperLink4" href="https://www.linkedin.com/company/pennsylvania-liquor-control-board" class="external" target="_blank">LinkedIn<span class="show-for-sr">Opens In A New Window</span><i class="pais pai-fw pai-external-link"></i></a>
                                     </span>
                                 </li>
                             
@@ -881,46 +963,67 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
             <div class="small-12 large-5 columns footer-left">
                 <div class="row footer-menu">
                     <div class="small-12 large-6 columns footer-img">
-                        <img src="https://assets.apps.pa.gov/SiteCollectionImages/palogo/open-data-pa-branding-footer-logo-white.png" id="ctl00_ctl76_imgGovernorsLogo" class="gov-seal" title="Governor&#39;s Logo" alt="Governor&#39;s Logo" />
+                        <img src="./PLCB Public Meetings_files/open-data-pa-branding-footer-logo-white.png" id="ctl00_ctl78_imgGovernorsLogo" class="gov-seal" title="Governor&#39;s Logo" alt="Governor&#39;s Logo">
                     </div>
                     <div class="small-12 large-6 columns">
-                        <a href="http://www.pa.gov/" id="ctl00_ctl76_aCommonwealthTitle" target="_blank" class="menu-link main-menu-link commonwealth-title">COMMONWEALTH OF PENNSYLVANIA</a>
-                        <p id="ctl00_ctl76_pCommonwealthParagraph">Keystone State. Proudly founded by William Penn in 1681 as a place of tolerance and freedom.</p>
+                        <a href="http://www.pa.gov/" id="ctl00_ctl78_aCommonwealthTitle" target="_blank" class="menu-link main-menu-link commonwealth-title">COMMONWEALTH OF PENNSYLVANIA</a>
+                        <p id="ctl00_ctl78_pCommonwealthParagraph">Keystone State. Proudly founded in 1681 as a place of tolerance and freedom.</p>
                     </div>
                 </div>
             </div>
             <div class="small-12 large-7 columns footer-right">
                 <div class="row footer-menu">
-                    <div id="ctl00_ctl76_divEnterpriseCategory1" class="small-12 large-4 columns">
-                        <a id="ctl00_ctl76_lnkEnterpriseCategory1" class="class menu-link main-menu-link" href="http://www.pa.gov/#" target="_blank">TOP SERVICES</a>
-                        <ul id="ctl00_ctl76_ulEnterpriseSubMenu1"><li class='sub-menu-item'><a target='_blank' href='https://www.pavoterservices.state.pa.us/Pages/VoterRegistrationApplication.aspx' class='menu-link sub-menu-link'><i class='fa fa-fw fa-check-square-o'></i><span>Register to Vote</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.dmv.state.pa.us/locator/locator.jsp?navigation=true' class='menu-link sub-menu-link'><i class='fa fa-fw fa-car'></i><span>Find a DMV</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://www.health.pa.gov/topics/certificates/Pages/Birth-Certificates.aspx' class='menu-link sub-menu-link'><i class='fa fa-fw fa-address-card-o'></i><span>Get a Birth Certificate</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://register.dmva.pa.gov/' class='menu-link sub-menu-link'><i class='fa fa-fw fa-flag'></i><span>Join the Veterans Registry</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://visitpa.com/' class='menu-link sub-menu-link'><i class='fa fa-fw fa-map-marker'></i><span>Visit Pennsylvania</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://pennwatch.pa.gov/Pages/default.aspx' class='menu-link sub-menu-link'><span>PennWatch</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.openrecords.pa.gov/RTKL/CitizensGuide.cfm' class='menu-link sub-menu-link'><span>Right-to-Know Law</span></a></li></ul>
+                    <div id="ctl00_ctl78_divEnterpriseCategory1" class="small-12 large-4 columns">
+                        <a id="ctl00_ctl78_lnkEnterpriseCategory1" class="class menu-link main-menu-link" href="http://www.pa.gov/#" target="_blank">TOP SERVICES</a>
+                        <ul id="ctl00_ctl78_ulEnterpriseSubMenu1"><li class="sub-menu-item"><a target="_blank" href="https://www.pavoterservices.state.pa.us/Pages/VoterRegistrationApplication.aspx" class="menu-link sub-menu-link"><i class="fa fa-fw fa-check-square-o"></i><span>Register to Vote</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.dmv.state.pa.us/locator/locator.jsp?navigation=true" class="menu-link sub-menu-link"><i class="fa fa-fw fa-car"></i><span>Find a DMV</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.health.pa.gov/topics/certificates/Pages/Birth-Certificates.aspx" class="menu-link sub-menu-link"><i class="fa fa-fw fa-address-card-o"></i><span>Get a Birth Certificate</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://register.dmva.pa.gov/" class="menu-link sub-menu-link"><i class="fa fa-fw fa-flag"></i><span>Join the Veterans Registry</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://visitpa.com/" class="menu-link sub-menu-link"><i class="fa fa-fw fa-map-marker"></i><span>Visit Pennsylvania</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://pennwatch.pa.gov/Pages/default.aspx" class="menu-link sub-menu-link"><i class="fa fa-fw fa-info-circle"></i><span>PennWatch</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.openrecords.pa.gov/RTKL/CitizensGuide.cfm" class="menu-link sub-menu-link"><i class="fa fa-fw fa-info-circle"></i><span>Right-to-Know Law</span></a></li></ul>
                     </div>
-                    <div id="ctl00_ctl76_divEnterpriseCategory2" class="small-12 large-4 columns">
-                        <a id="ctl00_ctl76_lnkEnterpriseCategory2" class="class menu-link main-menu-link" href="http://www.pa.gov/#government" target="_blank">GOVERNMENT</a>
-                        <ul id="ctl00_ctl76_ulEnterpriseSubMenu2"><li class='sub-menu-item'><a target='_blank' href='https://www.governor.pa.gov/' class='menu-link sub-menu-link'><i class='fa fa-fw fa-star'></i><span>Governor Tom Wolf</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.house.state.pa.us/' class='menu-link sub-menu-link'><span>State House</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.pasen.gov/' class='menu-link sub-menu-link'><span>State Senate</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.pacourts.us/' class='menu-link sub-menu-link'><span>Courts</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://www.governor.pa.gov/lieutenant-governor/' class='menu-link sub-menu-link'><span>Lieutenant Governor</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://www.attorneygeneral.gov/' class='menu-link sub-menu-link'><span>Attorney General</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.paauditor.gov/' class='menu-link sub-menu-link'><span>Auditor General</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.patreasury.gov/' class='menu-link sub-menu-link'><span>Treasurer</span></a></li></ul>
+                    <div id="ctl00_ctl78_divEnterpriseCategory2" class="small-12 large-4 columns">
+                        <a id="ctl00_ctl78_lnkEnterpriseCategory2" class="class menu-link main-menu-link" href="http://www.pa.gov/#government" target="_blank">GOVERNMENT</a>
+                        <ul id="ctl00_ctl78_ulEnterpriseSubMenu2"><li class="sub-menu-item"><a target="_blank" href="https://www.governor.pa.gov/" class="menu-link sub-menu-link"><i class="fa fa-fw fa-star"></i><span>Governor Tom Wolf</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.pa.gov/directory/" class="menu-link sub-menu-link"><i class="fa fa-fw fa-address-book"></i><span>Directory</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.house.state.pa.us/" class="menu-link sub-menu-link"><span>State House</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.pasen.gov/" class="menu-link sub-menu-link"><span>State Senate</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.pacourts.us/" class="menu-link sub-menu-link"><span>Courts</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.ltgov.pa.gov/Pages/Home.aspx" class="menu-link sub-menu-link"><span>Lieutenant Governor</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.attorneygeneral.gov/" class="menu-link sub-menu-link"><span>Attorney General</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.paauditor.gov/" class="menu-link sub-menu-link"><span>Auditor General</span></a></li><li class="sub-menu-item"><a target="_blank" href="http://www.patreasury.gov/" class="menu-link sub-menu-link"><span>Treasurer</span></a></li></ul>
                     </div>
-                    <div id="ctl00_ctl76_divEnterpriseCategory3" class="small-12 large-4 columns">
-                        <a id="ctl00_ctl76_lnkEnterpriseCategory3" class="class menu-link main-menu-link" href="http://www.pa.gov/" target="_blank">PA.GOV</a>
-                        <ul id="ctl00_ctl76_ulEnterpriseSubMenu3"><li class='sub-menu-item'><a target='_blank' href='https://www.pa.gov/directory/' class='menu-link sub-menu-link'><i class='fa fa-fw fa-address-book'></i><span>Directory</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://www.facebook.com/PennsylvaniaGov/' class='menu-link sub-menu-link'><i class='fa fa-fw fa-facebook-official'></i><span>Like Pennsylvania on Facebook</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://twitter.com/PennsylvaniaGov' class='menu-link sub-menu-link'><i class='fa fa-fw fa-twitter-square'></i><span>Follow Pennsylvania on Twitter</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://www.pa.gov/news/' class='menu-link sub-menu-link'><span>News</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://www.pa.gov/directory/' class='menu-link sub-menu-link'><span>Social Media</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://pa.gov/apps/' class='menu-link sub-menu-link'><span>Apps</span></a></li><li class='sub-menu-item'><a target='_blank' href='https://www.pa.gov/guides/commonwealth-careers/' class='menu-link sub-menu-link'><span>Careers</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.pennfellowship.pa.gov/Pages/default.aspx' class='menu-link sub-menu-link'><span>William Penn Fellowship</span></a></li><li class='sub-menu-item'><a target='_blank' href='http://www.employment.pa.gov/internships/Pages/default.aspx' class='menu-link sub-menu-link'><span>Internships</span></a></li></ul>
+                    <div id="ctl00_ctl78_divEnterpriseCategory3" class="small-12 large-4 columns">
+                        <a id="ctl00_ctl78_lnkEnterpriseCategory3" class="class menu-link main-menu-link" href="http://www.pa.gov/" target="_blank">PA.GOV</a>
+                        <ul id="ctl00_ctl78_ulEnterpriseSubMenu3"><li class="sub-menu-item"><a target="_blank" href="https://wslh.dced.pa.gov/" class="menu-link sub-menu-link"><i class="fa fa-fw fa-map-signs"></i><span>Who We Are</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.facebook.com/PennsylvaniaGov/" class="menu-link sub-menu-link"><i class="fa fa-fw fa-facebook-official"></i><span>Pennsylvania Facebook</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://twitter.com/PennsylvaniaGov" class="menu-link sub-menu-link"><i class="fa fa-fw fa-twitter-square"></i><span>Pennsylvania Twitter</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.pa.gov/guides/state-symbols/" class="menu-link sub-menu-link"><span>State Symbols</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.pa.gov/news/" class="menu-link sub-menu-link"><span>News</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.pa.gov/directory/" class="menu-link sub-menu-link"><span>Social Media</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://pa.gov/apps/" class="menu-link sub-menu-link"><span>Apps</span></a></li><li class="sub-menu-item"><a target="_blank" href="https://www.pa.gov/guides/commonwealth-careers/" class="menu-link sub-menu-link"><span>Careers &amp; Internships</span></a></li></ul>
                     </div>
                 </div>
             </div>
         </div>
     </nav>
     <nav id="copyright" class="clearfix row copyright-nav">
-        <ul id="ctl00_ctl76_ulBottomStrip" class="small-12 large-6 columns">
-        <li><a target='_blank' href='http://www.pa.gov/accessibility-policy/'>ACCESSIBILITY</a></li><li><a target='_blank' href='http://www.pa.gov/privacy-policy/'>PRIVACY & DISCLAIMERS</a></li><li><a target='_blank' href='https://www.pa.gov/translation-disclaimer/'>TRANSLATION DISCLAIMER</a></li><li><a target='_blank' href='http://www.pa.gov/security-policy/'>SECURITY</a></li></ul>
-        <p class="small-12 large-6 columns">
+        <ul id="ctl00_ctl78_ulBottomStrip" class="small-12 large-6 columns">
+        <li><a target="_blank" href="http://www.pa.gov/accessibility-policy/">ACCESSIBILITY</a></li><li><a target="_blank" href="http://www.pa.gov/privacy-policy/">PRIVACY &amp; DISCLAIMERS</a></li><li><a target="_blank" href="https://www.pa.gov/translation-disclaimer/">TRANSLATION DISCLAIMER</a></li><li><a target="_blank" href="http://www.pa.gov/security-policy/">SECURITY</a></li></ul>
+        <span class="small-12 large-6 columns">
             Copyright ©
-                <span id="ctl00_ctl76_lblYear">2019</span>
+                <span id="ctl00_ctl78_lblYear">2020</span>
             Commonwealth of Pennsylvania. All rights reserved.
-        </p>
+        </span>
     </nav>
 </footer>
 
 
             <!--SPG: Custom Header-->
             
+<script>
+   
+    var defaultBannerText;
+    
+    $(document).ready(function () {
+        try {
+            if (!allCarousels) {
+               if(!bannerLabel) {
+                    defaultBannerText = ($("#ctl00_ctl80_hfdefaultimgalt").val());
+                    $('.banner').attr('aria-label', defaultBannerText);
+                }
+            }
+        }
+        catch(err) {
+           defaultBannerText = ($("#ctl00_ctl80_hfdefaultimgalt").val());
+           $('.banner').attr('aria-label', defaultBannerText);
+        }
+    });
+</script>
+<input type="hidden" name="ctl00$ctl80$hfdefaultimgalt" id="ctl00_ctl80_hfdefaultimgalt">
+
             <!--SPG: Agency Assets Delegate Control-->
             
             <!--SPG:End PAI Delegate Control Section-->
@@ -959,13 +1062,13 @@ Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', 'aspnetForm',
 <script type="text/javascript">
 //<![CDATA[
 var _spFormDigestRefreshInterval = 1440000;window.g_updateFormDigestPageLoaded = new Date(); window.g_updateFormDigestPageLoaded.setDate(window.g_updateFormDigestPageLoaded.getDate() -5);
-WebForm_InitCallback();
-                    function DoPagingCallbackctl00$ctl49$g_b385e5b0_48cb_4981_a437_1a7a9755faea(pagingInputs) {WebForm_DoCallback('ctl00$ctl49$g_b385e5b0_48cb_4981_a437_1a7a9755faea',pagingInputs,UpdatePaging,0,CallBackError,true) } 
 if (typeof(_spBodyOnLoadFunctionNames) != "undefined") {
 if (_spBodyOnLoadFunctionNames != null) {
 _spBodyOnLoadFunctionNames.push("ExpDataViewGroupOnPageLoad");
 }
-}var _fV4UI = true;
+}
+WebForm_InitCallback();
+                    function DoPagingCallbackctl00$ctl49$g_b385e5b0_48cb_4981_a437_1a7a9755faea(pagingInputs) {WebForm_DoCallback('ctl00$ctl49$g_b385e5b0_48cb_4981_a437_1a7a9755faea',pagingInputs,UpdatePaging,0,CallBackError,true) } var _fV4UI = true;
 function _RegisterWebPartPageCUI()
 {
     var initInfo = {editable: false,isEditMode: false,allowWebPartAdder: false,listId: "{fcb04add-3188-47aa-a961-12029f49f687}",itemId: 3,recycleBinEnabled: true,enableMinorVersioning: true,enableModeration: false,forceCheckout: true,rootFolderUrl: "\u002fAbout-Us\u002fBoard\u002fPages",itemPermissions:{High:16,Low:196673}};
@@ -995,7 +1098,10 @@ function _RegisterWebPartPageCUI()
 };
 function __RegisterWebPartPageCUI() {
 ExecuteOrDelayUntilScriptLoaded(_RegisterWebPartPageCUI, "sp.ribbon.js");}
-_spBodyOnLoadFunctionNames.push("__RegisterWebPartPageCUI");var __wpmExportWarning='This Web Part Page has been personalized. As a result, one or more Web Part properties may contain confidential information. Make sure the properties contain information that is safe for others to read. After exporting this Web Part, view properties in the Web Part description file (.WebPart) by using a text editor such as Microsoft Notepad.';var __wpmCloseProviderWarning='You are about to close this Web Part.  It is currently providing data to other Web Parts, and these connections will be deleted if this Web Part is closed.  To close this Web Part, click OK.  To keep this Web Part, click Cancel.';var __wpmDeleteWarning='You are about to permanently delete this Web Part.  Are you sure you want to do this?  To delete this Web Part, click OK.  To keep this Web Part, click Cancel.';
+_spBodyOnLoadFunctionNames.push("__RegisterWebPartPageCUI");var __wpmExportWarning='This Web Part Page has been personalized. As a result, one or more Web Part properties may contain confidential information. Make sure the properties contain information that is safe for others to read. After exporting this Web Part, view properties in the Web Part description file (.WebPart) by using a text editor such as Microsoft Notepad.';var __wpmCloseProviderWarning='You are about to close this Web Part.  It is currently providing data to other Web Parts, and these connections will be deleted if this Web Part is closed.  To close this Web Part, click OK.  To keep this Web Part, click Cancel.';var __wpmDeleteWarning='You are about to permanently delete this Web Part.  Are you sure you want to do this?  To delete this Web Part, click OK.  To keep this Web Part, click Cancel.';var offlineBtnText = '';var offlineBtnImg = '';ExecuteOrDelayUntilScriptLoaded(function() {var objStsSync = GetStssyncData('documents','Client', '', '/_layouts/15/images/menu');
+if(objStsSync){ offlineBtnText = objStsSync.BtnText;
+offlineBtnImg = objStsSync.BtnImagePath;
+}}, 'strings.js');
 window.CoreJsApiPresent = true;
 window.ExecuteOrDelayUntilScriptLoaded && ExecuteOrDelayUntilScriptLoaded(function()
 {
@@ -1007,14 +1113,11 @@ window.ExecuteOrDelayUntilScriptLoaded && ExecuteOrDelayUntilScriptLoaded(functi
     fnReg(ns, shim, ns + '.ShimPlaceholder', 2);
 }, 
                              'JsApiExtensibilityManager.js');Type.registerNamespace('SP.SPGantt.InstrumentedApi');
-              SP.SPGantt.InstrumentedApi.ExecuteWithJsApiLoaded = function(fn) { var fnEx = window.ExecuteOrDelayUntilScriptLoaded && ExecuteOrDelayUntilScriptLoaded; fnEx && fnEx(function() { JsApi.ExtensibilityManager.ExecuteWithJsApisInNamespaceLoaded('SP.SPGantt.InstrumentedApi', fn); }, 'JsApiExtensibilityManager.js'); };if(typeof g_spPreFetchKeys != 'undefined'){ g_spPreFetchKeys.push('DragDrop.js'); _spBodyOnLoadFunctionNames.push('WPQRegisterDragDropUpload'); g_spDragDropUpload['WebPartWPQ2'] = new SPDragUploadInfo('WebPartWPQ2','https:\u002f\u002fwww.lcb.pa.gov','\u002fAbout-Us\u002fBoard','{3EEBADA2-E8EC-4AF1-97F1-43643078072B}','\u002fCurrent Year Board Agendas and Meeting Minutes', false, false, null, null, null, null);}g_spPreFetchKeys.push('sharing.js');g_spPreFetchKeys.push('callout.js');var offlineBtnText = '';var offlineBtnImg = '';ExecuteOrDelayUntilScriptLoaded(function() {var objStsSync = GetStssyncData('documents','Client', '', '/_layouts/15/images/menu');
-if(objStsSync){ offlineBtnText = objStsSync.BtnText;
-offlineBtnImg = objStsSync.BtnImagePath;
-}}, 'strings.js');if(typeof g_spPreFetchKeys != 'undefined'){ g_spPreFetchKeys.push('DragDrop.js'); _spBodyOnLoadFunctionNames.push('WPQRegisterDragDropUpload'); g_spDragDropUpload['WebPartWPQ3'] = new SPDragUploadInfo('WebPartWPQ3','https:\u002f\u002fwww.lcb.pa.gov','\u002fAbout-Us\u002fBoard','{36974D54-7289-477F-8407-F203F5F3F499}','\u002fDocuments', false, false, null, null, null, null);}g_spPreFetchKeys.push('sharing.js');g_spPreFetchKeys.push('callout.js');if(typeof g_spPreFetchKeys != 'undefined'){ g_spPreFetchKeys.push('DragDrop.js'); _spBodyOnLoadFunctionNames.push('WPQRegisterDragDropUpload'); g_spDragDropUpload['WebPartWPQ4'] = new SPDragUploadInfo('WebPartWPQ4','https:\u002f\u002fwww.lcb.pa.gov','\u002fAbout-Us\u002fBoard','{36974D54-7289-477F-8407-F203F5F3F499}','\u002fDocuments', false, false, null, null, null, null);}g_spPreFetchKeys.push('sharing.js');g_spPreFetchKeys.push('callout.js');var g_clientIdDeltaPlaceHolderMain = "DeltaPlaceHolderMain";
+              SP.SPGantt.InstrumentedApi.ExecuteWithJsApiLoaded = function(fn) { var fnEx = window.ExecuteOrDelayUntilScriptLoaded && ExecuteOrDelayUntilScriptLoaded; fnEx && fnEx(function() { JsApi.ExtensibilityManager.ExecuteWithJsApisInNamespaceLoaded('SP.SPGantt.InstrumentedApi', fn); }, 'JsApiExtensibilityManager.js'); };if(typeof g_spPreFetchKeys != 'undefined'){ g_spPreFetchKeys.push('DragDrop.js'); _spBodyOnLoadFunctionNames.push('WPQRegisterDragDropUpload'); g_spDragDropUpload['WebPartWPQ2'] = new SPDragUploadInfo('WebPartWPQ2','https:\u002f\u002fwww.lcb.pa.gov','\u002fAbout-Us\u002fBoard','{36974D54-7289-477F-8407-F203F5F3F499}','\u002fDocuments', false, false, null, null, null, null);}g_spPreFetchKeys.push('sharing.js');g_spPreFetchKeys.push('callout.js');if(typeof g_spPreFetchKeys != 'undefined'){ g_spPreFetchKeys.push('DragDrop.js'); _spBodyOnLoadFunctionNames.push('WPQRegisterDragDropUpload'); g_spDragDropUpload['WebPartWPQ3'] = new SPDragUploadInfo('WebPartWPQ3','https:\u002f\u002fwww.lcb.pa.gov','\u002fAbout-Us\u002fBoard','{36974D54-7289-477F-8407-F203F5F3F499}','\u002fDocuments', false, false, null, null, null, null);}g_spPreFetchKeys.push('sharing.js');g_spPreFetchKeys.push('callout.js');if(typeof g_spPreFetchKeys != 'undefined'){ g_spPreFetchKeys.push('DragDrop.js'); _spBodyOnLoadFunctionNames.push('WPQRegisterDragDropUpload'); g_spDragDropUpload['WebPartWPQ4'] = new SPDragUploadInfo('WebPartWPQ4','https:\u002f\u002fwww.lcb.pa.gov','\u002fAbout-Us\u002fBoard','{3EEBADA2-E8EC-4AF1-97F1-43643078072B}','\u002fCurrent Year Board Agendas and Meeting Minutes', false, false, null, null, null, null);}g_spPreFetchKeys.push('sharing.js');g_spPreFetchKeys.push('callout.js');var g_clientIdDeltaPlaceHolderMain = "DeltaPlaceHolderMain";
 var g_clientIdDeltaPlaceHolderUtilityContent = "DeltaPlaceHolderUtilityContent";
-var WPQ2ListData = { "Row" : 
+var WPQ4ListData = { "Row" : 
 [{
-"ID": "120",
+"ID": "148",
 "PermMask": "0x1000030041",
 "FSObjType": "0",
 "HTML_x0020_File_x0020_Type": "",
@@ -1026,8 +1129,8 @@ var WPQ2ListData = { "Row" :
 "ServerRedirectedEmbedUrl": "",
 "File_x0020_Type.progid": "",
 "File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fCurrent Year Board Agendas and Meeting Minutes\u002fJanuary 30, 2019.pdf",
-"FileLeafRef": "January 30, 2019.pdf",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fCurrent Year Board Agendas and Meeting Minutes\u002fJanuary 29, 2020.pdf",
+"FileLeafRef": "January 29, 2020.pdf",
 "CheckoutUser": "",
 "CheckedOutUserId": "",
 "IsCheckedoutToLocal": "0",
@@ -1037,7 +1140,7 @@ var WPQ2ListData = { "Row" :
 "Order0.": "2.00000000000000"
 }
 ,{
-"ID": "119",
+"ID": "147",
 "PermMask": "0x1000030041",
 "FSObjType": "0",
 "HTML_x0020_File_x0020_Type": "",
@@ -1049,8 +1152,8 @@ var WPQ2ListData = { "Row" :
 "ServerRedirectedEmbedUrl": "",
 "File_x0020_Type.progid": "",
 "File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fCurrent Year Board Agendas and Meeting Minutes\u002fJanuary 16, 2019.pdf",
-"FileLeafRef": "January 16, 2019.pdf",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fCurrent Year Board Agendas and Meeting Minutes\u002fJanuary 15, 2020.pdf",
+"FileLeafRef": "January 15, 2020.pdf",
 "CheckoutUser": "",
 "CheckedOutUserId": "",
 "IsCheckedoutToLocal": "0",
@@ -1065,7 +1168,7 @@ var WPQ2ListData = { "Row" :
 ,"ForceNoHierarchy" : "1"
 ,"HierarchyHasIndention" : ""
 
-};var WPQ2SchemaData = { "Field": [ 
+};var WPQ4SchemaData = { "Field": [ 
 {"Name": "DocIcon",
 "FieldType": "Computed",
 "RealFieldName": "DocIcon",
@@ -1098,10 +1201,10 @@ var WPQ2ListData = { "Row" :
 ,"Toolbar" : "None"
 };
           ctx = new ContextInfo();
-          ctx.wpq= "WPQ2";
+          ctx.wpq= "WPQ4";
           ctx.Templates = {};
-          ctx.ListData = WPQ2ListData;
-          ctx.ListSchema = WPQ2SchemaData;
+          ctx.ListData = WPQ4ListData;
+          ctx.ListSchema = WPQ4SchemaData;
           ctx.BaseViewID = 1;
           ctx.ListTemplateType = 101;
           
@@ -1155,19 +1258,19 @@ var WPQ2ListData = { "Row" :
           ctx.newFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=8&ListId=%7B3EEBADA2%2DE8EC%2D4AF1%2D97F1%2D43643078072B%7D&RootFolder=";
           ctx.editFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=6&ListId=%7B3EEBADA2%2DE8EC%2D4AF1%2D97F1%2D43643078072B%7D";
           ctx.isWebEditorPreview = 0;
-          ctx.ctxId = 34;
+          ctx.ctxId = 429;
           ctx.isXslView = true;
           ctx.IsClientRendering = true;
           if (g_ViewIdToViewCounterMap["{B2F22707-7334-4E25-8162-32199003BEA3}"] == null)
-              g_ViewIdToViewCounterMap["{B2F22707-7334-4E25-8162-32199003BEA3}"]= 34;
+              g_ViewIdToViewCounterMap["{B2F22707-7334-4E25-8162-32199003BEA3}"]= 429;
           ctx.CurrentUserId = -1;
           
           ctx.RegionalSettingsTimeZoneBias = "300";
           
             ctx.AllowCreateFolder = true;
           
-          ctx34 = ctx;
-          g_ctxDict['ctx34'] = ctx;
+          ctx429 = ctx;
+          g_ctxDict['ctx429'] = ctx;
       
         function IsSharePointOpenDocuments( test )
         {
@@ -1195,693 +1298,9 @@ var WPQ2ListData = { "Row" :
         }
         fNewDoc = IsSharePointOpenDocuments(EditDocumentButton);
       
-      ctx34.bInitialRender = true;
-      RenderListView(ctx34, 'WPQ2');
-      ctx34.bInitialRender = false;
-    var WPQ4ListData = { "Row" : 
-[{
-"ID": "96",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fApril 19, 2017.pdf",
-"FileLeafRef": "April 19, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "5\u002f3\u002f2017 12:15 PM",
-"Modified.FriendlyDisplay": "0|May 3, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "95",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fApril 5, 2017.pdf",
-"FileLeafRef": "April 5, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "4\u002f19\u002f2017 2:39 PM",
-"Modified.FriendlyDisplay": "0|April 19, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "102",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fAugust 2, 2017.pdf",
-"FileLeafRef": "August 2, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "8\u002f23\u002f2017 11:55 AM",
-"Modified.FriendlyDisplay": "0|August 23, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "103",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fAugust 23, 2017.pdf",
-"FileLeafRef": "August 23, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "9\u002f13\u002f2017 12:19 PM",
-"Modified.FriendlyDisplay": "0|September 13, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "111",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fDecember 20, 2017.pdf",
-"FileLeafRef": "December 20, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "1\u002f17\u002f2018 12:06 PM",
-"Modified.FriendlyDisplay": "0|January 17, 2018",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "110",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fDecember 6, 2017.pdf",
-"FileLeafRef": "December 6, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "12\u002f20\u002f2017 11:29 AM",
-"Modified.FriendlyDisplay": "0|December 20, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "91",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fFebruary 1, 2017.pdf",
-"FileLeafRef": "February 1, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "2\u002f15\u002f2017 12:00 PM",
-"Modified.FriendlyDisplay": "0|February 15, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "92",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fFebruary 15, 2017.pdf",
-"FileLeafRef": "February 15, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "3\u002f8\u002f2017 11:33 AM",
-"Modified.FriendlyDisplay": "0|March 8, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "90",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJanuary 18, 2017.pdf",
-"FileLeafRef": "January 18, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "2\u002f1\u002f2017 12:00 PM",
-"Modified.FriendlyDisplay": "0|February 1, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "101",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJuly 19, 2017.pdf",
-"FileLeafRef": "July 19, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "8\u002f2\u002f2017 11:58 AM",
-"Modified.FriendlyDisplay": "0|August 2, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "100",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJune 28, 2017.pdf",
-"FileLeafRef": "June 28, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "7\u002f19\u002f2017 11:38 AM",
-"Modified.FriendlyDisplay": "0|July 19, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "99",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJune 7, 2017.pdf",
-"FileLeafRef": "June 7, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "6\u002f28\u002f2017 11:38 AM",
-"Modified.FriendlyDisplay": "0|June 28, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "94",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fMarch 22, 2017.pdf",
-"FileLeafRef": "March 22, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "4\u002f5\u002f2017 11:48 AM",
-"Modified.FriendlyDisplay": "0|April 5, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "98",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fMay 17, 2017.pdf",
-"FileLeafRef": "May 17, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "6\u002f7\u002f2017 12:02 PM",
-"Modified.FriendlyDisplay": "0|June 7, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "97",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fMay 3, 2017.pdf",
-"FileLeafRef": "May 3, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "5\u002f17\u002f2017 12:05 PM",
-"Modified.FriendlyDisplay": "0|May 17, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "108",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fNovember 1, 2017.pdf",
-"FileLeafRef": "November 1, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "11\u002f15\u002f2017 12:48 PM",
-"Modified.FriendlyDisplay": "0|November 15, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "109",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fNovember 15, 2017.pdf",
-"FileLeafRef": "November 15, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "12\u002f6\u002f2017 12:02 PM",
-"Modified.FriendlyDisplay": "0|December 6, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "106",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fOctober 11, 2017.pdf",
-"FileLeafRef": "October 11, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "10\u002f23\u002f2017 9:43 AM",
-"Modified.FriendlyDisplay": "0|October 23, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "107",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fOctober 20, 2017.pdf",
-"FileLeafRef": "October 20, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "11\u002f1\u002f2017 12:32 PM",
-"Modified.FriendlyDisplay": "0|November 1, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "104",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fSeptember 13, 2017.pdf",
-"FileLeafRef": "September 13, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "9\u002f27\u002f2017 11:48 AM",
-"Modified.FriendlyDisplay": "0|September 27, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-,{
-"ID": "105",
-"PermMask": "0x1000030041",
-"FSObjType": "0",
-"HTML_x0020_File_x0020_Type": "",
-"File_x0020_Type": "pdf",
-"File_x0020_Type.mapapp": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
-"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
-"serverurl.progid": "",
-"ServerRedirectedEmbedUrl": "",
-"File_x0020_Type.progid": "",
-"File_x0020_Type.url": "FALSE",
-"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fSeptember 27, 2017.pdf",
-"FileLeafRef": "September 27, 2017.pdf",
-"CheckoutUser": "",
-"CheckedOutUserId": "",
-"IsCheckedoutToLocal": "0",
-"Created_x0020_Date.ifnew": "",
-"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
-"Modified": "10\u002f11\u002f2017 11:39 AM",
-"Modified.FriendlyDisplay": "0|October 11, 2017",
-"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
-}
-],"FirstRow" : 1,
-"LastRow" : 21
-,"FilterLink" : "?"
-,"ForceNoHierarchy" : "1"
-,"HierarchyHasIndention" : ""
-
-};var WPQ4SchemaData = { "Field": [ 
-{"Name": "DocIcon",
-"FieldType": "Computed",
-"RealFieldName": "DocIcon",
-"DisplayName": "Type",
-"ID": "081c6e4c-5c14-4f20-b23e-1a71ceb6a67c",
-"ReadOnly": "TRUE",
-"ClassInfo": "Icon",
-"Type": "Computed",
-"AllowGridEditing": "FALSE"}
-,{"Name": "LinkFilename",
-"FieldType": "Computed",
-"RealFieldName": "FileLeafRef",
-"DisplayName": "Name",
-"ID": "5cc6dc79-3710-4374-b433-61cb4a686c12",
-"ClassInfo": "Menu",
-"Type": "Computed",
-"Filterable": "FALSE",
-"listItemMenu": "TRUE",
-"CalloutMenu": "TRUE",
-"AllowGridEditing": "TRUE"}
-,{"Name": "Modified",
-"FieldType": "DateTime",
-"RealFieldName": "Modified",
-"DisplayName": "Modified",
-"ID": "28cf69c5-fa48-462a-b5cd-27b6f9d2bd5f",
-"ReadOnly": "TRUE",
-"Type": "DateTime",
-"AllowGridEditing": "FALSE"}
-,{"Name": "Editor",
-"FieldType": "User",
-"RealFieldName": "Editor",
-"DisplayName": "Modified By",
-"ID": "d31655d1-1d5b-4511-95a1-7a09e9b75bf2",
-"ReadOnly": "TRUE",
-"ImnHeader": "TRUE",
-"DefaultRender": "1",
-"Type": "User",
-"AllowGridEditing": "FALSE"}
-],"LCID" : "1033","Userid" : ""
-,"PagePath" : "/About-Us/Board/Pages/Public-Meetings.aspx"
-,"ShowWebPart" : ""
-,"View" : "{6B982743-ACEB-457F-96B7-D1E33DA995EB}"
-,"RootFolderParam" : "View={6b982743-aceb-457f-96b7-d1e33da995eb}&"
-,"FieldSortParam" : ""
-,"HttpVDir" : "https://www.lcb.pa.gov/About-Us/Board"
-,"IsDocLib" : "1"
-,"UIVersion" : "15","NoListItem" : "There are no items to show in this view of the \"2017 Meeting Minutes\" document library.","NoListItemHowTo" : "To add a new item, click \"New\" or \"Upload\".","DefaultItemOpen" : "1","ForceCheckout" : "0","Direction" : "none","TabularView" : "1","PresenceAlt" : "No presence information"
-,"UserDispUrl" : "/About-Us/Board/_layouts/15/userdisp.aspx"
-,"SelectedID" : "-1"
-,"Toolbar" : "Standard"
-};function _initTRAWebPartWPQ4()
-{var toolbarData = new Object();toolbarData['ToolbarData'] = "[{'Command':'OpenWithExplorer','ClickScript':'CoreInvoke\\u0028\\u0027NavigateHttpFolder\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027, \\u0027_blank\\u0027\\u0029;','HiddenScript':'!\\u0028SupportsNavigateHttpFolder\\u0028\\u0029\\u0029','LabelText':'Open with Windows Explorer','Description':'Drag and drop files into this library.'},{'Command':'ConnectToClient','ClickScript':'javaScript:ExportHailStorm\\u0028\\u0027documents\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\u0027,\\u0027{36974d54-7289-477f-8407-f203f5f3f499}\\u0027,\\u0027Board\\u0027,\\u00272017 Meeting Minutes\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027,\\u0027\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027\\u0029;','HiddenScript':'!offlineBtnText','Description':'Synchronize items and make them available offline.'},{'Command':'ExportToSpreadsheet','ClickScript':'javaScript:ExportList\\u0028\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002f_vti_bin\\\\u002fowssvr.dll?CS=65001\\\\u0026Using=_layouts\\\\u002f15\\\\u002fquery.iqy\\\\u0026List=\\\\u00257B36974D54\\\\u00252D7289\\\\u00252D477F\\\\u00252D8407\\\\u00252DF203F5F3F499\\\\u00257D\\\\u0026View=\\\\u00257B6B982743\\\\u00252DACEB\\\\u00252D457F\\\\u00252D96B7\\\\u00252DD1E33DA995EB\\\\u00257D\\\\u0026RootFolder=\\\\u00252FAbout\\\\u00252DUs\\\\u00252FBoard\\\\u00252FDocuments\\\\u0026CacheControl=1\\u0027\\u0029','LabelText':'Export to Spreadsheet','Description':'Analyze items with a spreadsheet application.'}]";
-toolbarData['ViewDropDownOptions']="{showRepairView : false, showMergeView : false, showEditView: false, showCreateView: false, showApproverView:  false, listId: '{36974D54-7289-477F-8407-F203F5F3F499}', viewId: '{6B982743-ACEB-457F-96B7-D1E33DA995EB}', viewParameters: ''}";
-toolbarData['ViewId']='6b982743-aceb-457f-96b7-d1e33da995eb';
-toolbarData['ViewName']='';
-toolbarData['ViewReadOnly']='false';
-toolbarData['BaseViewId']='1';
-toolbarData['ListId']='36974d54-7289-477f-8407-f203f5f3f499';
-toolbarData['ListEnableAttachments']='False';
-toolbarData['ListBaseType']='1';
-toolbarData['ListTemplateType']='101';
-toolbarData['ListPermissions']='{High:16,Low:196673}';
-toolbarData['ListFolderPermissions']='{High:16,Low:196673}';
-toolbarData['ListHasExternalDataSource']='False';
-toolbarData['ServerRelativeWebUrl']='\u002fAbout-Us\u002fBoard';
-toolbarData['IsAppWeb']=false;
-SP.Ribbon.PageManager.get_instance().addPageComponent(new SP.Ribbon.DocLibWebPartPageComponent('WebPartWPQ4',toolbarData));
-}
-ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ4, "sp.ribbon.js");
-          ctx = new ContextInfo();
-          ctx.wpq= "WPQ4";
-          ctx.Templates = {};
-          ctx.ListData = WPQ4ListData;
-          ctx.ListSchema = WPQ4SchemaData;
-          ctx.BaseViewID = 1;
-          ctx.ListTemplateType = 101;
-          
-          ctx.existingServerFilterHash = ajaxNavigate.getParam("ServerFilter");
-          if (null != ctx.existingServerFilterHash) {
-            ctx.existingServerFilterHash = ctx.existingServerFilterHash.replace(/-/g, '&').replace(/&&/g, '-');
-            var serverFilterRootFolder = GetUrlKeyValue("RootFolder", true,ctx.existingServerFilterHash);
-            var currentRootFolder = GetUrlKeyValue("RootFolder", true);
-            if("" == serverFilterRootFolder && "" != currentRootFolder)
-            {
-              ctx.existingServerFilterHash += "&RootFolder=" + currentRootFolder;
-            }
-            var uri=new URI(ajaxNavigate.get_href());
-            uri.setFragment("");
-            uri.setQuery(ctx.existingServerFilterHash);
-            STSNavigate(uri.getString());
-          }
-          
-              ctx.listBaseType = 1;
-          
-            ctx.noGroupCollapse = true;
-          
-          ctx.NavigateForFormsPages = false;
-          ctx.BasePermissions = {ManageLists: false, ManagePersonalViews: false, OpenItems: false};
-          ctx.CurrentUserIsSiteAdmin = false;
-          ctx.IsAppWeb = false;
-          ctx.AllowGridMode = false;
-          ctx.inGridMode = false;
-          ctx.listTemplate = "101";
-          ctx.listName = "{36974D54-7289-477F-8407-F203F5F3F499}";
-          ctx.rootFolder = "";
-          ctx.view = "{6B982743-ACEB-457F-96B7-D1E33DA995EB}";
-          ctx.viewTitle = "";
-          ctx.listUrlDir = "/About-Us/Board/Documents";
-          ctx.HttpPath = "https://www.lcb.pa.gov/About-Us/Board/_vti_bin/owssvr.dll?CS=65001";
-          ctx.HttpRoot = "https://www.lcb.pa.gov/About-Us/Board";
-          ctx.imagesPath = "/_layouts/15/images/";
-          ctx.PortalUrl = "";
-          ctx.SendToLocationName = "";
-          ctx.SendToLocationUrl = "";
-          
-              ctx.RecycleBinEnabled = 1;
-            
-          ctx.OfficialFileName = "";
-          ctx.OfficialFileNames = "";
-          ctx.WriteSecurity = "1";
-          ctx.SiteTitle = "Board";
-          ctx.ListTitle = "2017 Meeting Minutes";
-          if (ctx.PortalUrl == "") ctx.PortalUrl = null;
-          ctx.displayFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=4&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D";
-          ctx.newFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=8&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D&RootFolder=";
-          ctx.editFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=6&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D";
-          ctx.isWebEditorPreview = 0;
-          ctx.ctxId = 36;
-          ctx.isXslView = true;
-          ctx.IsClientRendering = true;
-          if (g_ViewIdToViewCounterMap["{6B982743-ACEB-457F-96B7-D1E33DA995EB}"] == null)
-              g_ViewIdToViewCounterMap["{6B982743-ACEB-457F-96B7-D1E33DA995EB}"]= 36;
-          ctx.CurrentUserId = -1;
-          
-            ctx.verEnabled = 1;
-          
-          ctx.RegionalSettingsTimeZoneBias = "300";
-          
-            ctx.AllowCreateFolder = true;
-          
-          ctx36 = ctx;
-          g_ctxDict['ctx36'] = ctx;
-      
-        function IsSharePointOpenDocuments( test )
-        {
-          if (test instanceof Array)
-            return false;
-          else
-            return (test != null) && typeof(test) == 'object';
-        }
-        var EditDocumentButton = [];
-        try {EditDocumentButton = new CreateObject("SharePoint.OpenDocuments.3");}
-        catch(err){}
-        if (IsSharePointOpenDocuments(EditDocumentButton))
-          fNewDoc3 = true;
-        else
-        {
-          try {EditDocumentButton = new CreateObject("SharePoint.OpenDocuments.2");}
-          catch(err){}
-          if (IsSharePointOpenDocuments(EditDocumentButton))
-            fNewDoc2 = true;
-          else
-          {
-            try {EditDocumentButton = new CreateObject("SharePoint.OpenDocuments.1");}
-            catch(err){}
-          }
-        }
-        fNewDoc = IsSharePointOpenDocuments(EditDocumentButton);
-      
-      ctx36.bInitialRender = true;
-      RenderListView(ctx36, 'WPQ4');
-      ctx36.bInitialRender = false;
+      ctx429.bInitialRender = true;
+      RenderListView(ctx429, 'WPQ4');
+      ctx429.bInitialRender = false;
     var WPQ3ListData = { "Row" : 
 [{
 "ID": "96",
@@ -2435,8 +1854,8 @@ ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ4, "sp.ribbon.js");
 ],"LCID" : "1033","Userid" : ""
 ,"PagePath" : "/About-Us/Board/Pages/Public-Meetings.aspx"
 ,"ShowWebPart" : ""
-,"View" : "{B1692D68-0638-405B-B4FD-3A8C40498E30}"
-,"RootFolderParam" : "View={b1692d68-0638-405b-b4fd-3a8c40498e30}&"
+,"View" : "{6B982743-ACEB-457F-96B7-D1E33DA995EB}"
+,"RootFolderParam" : "View={6b982743-aceb-457f-96b7-d1e33da995eb}&"
 ,"FieldSortParam" : ""
 ,"HttpVDir" : "https://www.lcb.pa.gov/About-Us/Board"
 ,"IsDocLib" : "1"
@@ -2445,9 +1864,9 @@ ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ4, "sp.ribbon.js");
 ,"SelectedID" : "-1"
 ,"Toolbar" : "Standard"
 };function _initTRAWebPartWPQ3()
-{var toolbarData = new Object();toolbarData['ToolbarData'] = "[{'Command':'OpenWithExplorer','ClickScript':'CoreInvoke\\u0028\\u0027NavigateHttpFolder\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027, \\u0027_blank\\u0027\\u0029;','HiddenScript':'!\\u0028SupportsNavigateHttpFolder\\u0028\\u0029\\u0029','LabelText':'Open with Windows Explorer','Description':'Drag and drop files into this library.'},{'Command':'ConnectToClient','ClickScript':'javaScript:ExportHailStorm\\u0028\\u0027documents\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\u0027,\\u0027{36974d54-7289-477f-8407-f203f5f3f499}\\u0027,\\u0027Board\\u0027,\\u00272017 Meeting Minutes\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027,\\u0027\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027\\u0029;','HiddenScript':'!offlineBtnText','Description':'Synchronize items and make them available offline.'},{'Command':'ExportToSpreadsheet','ClickScript':'javaScript:ExportList\\u0028\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002f_vti_bin\\\\u002fowssvr.dll?CS=65001\\\\u0026Using=_layouts\\\\u002f15\\\\u002fquery.iqy\\\\u0026List=\\\\u00257B36974D54\\\\u00252D7289\\\\u00252D477F\\\\u00252D8407\\\\u00252DF203F5F3F499\\\\u00257D\\\\u0026View=\\\\u00257BB1692D68\\\\u00252D0638\\\\u00252D405B\\\\u00252DB4FD\\\\u00252D3A8C40498E30\\\\u00257D\\\\u0026RootFolder=\\\\u00252FAbout\\\\u00252DUs\\\\u00252FBoard\\\\u00252FDocuments\\\\u0026CacheControl=1\\u0027\\u0029','LabelText':'Export to Spreadsheet','Description':'Analyze items with a spreadsheet application.'}]";
-toolbarData['ViewDropDownOptions']="{showRepairView : false, showMergeView : false, showEditView: false, showCreateView: false, showApproverView:  false, listId: '{36974D54-7289-477F-8407-F203F5F3F499}', viewId: '{B1692D68-0638-405B-B4FD-3A8C40498E30}', viewParameters: ''}";
-toolbarData['ViewId']='b1692d68-0638-405b-b4fd-3a8c40498e30';
+{var toolbarData = new Object();toolbarData['ToolbarData'] = "[{'Command':'OpenWithExplorer','ClickScript':'CoreInvoke\\u0028\\u0027NavigateHttpFolder\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027, \\u0027_blank\\u0027\\u0029;','HiddenScript':'!\\u0028SupportsNavigateHttpFolder\\u0028\\u0029\\u0029','LabelText':'Open with Windows Explorer','Description':'Drag and drop files into this library.'},{'Command':'ConnectToClient','ClickScript':'javaScript:ExportHailStorm\\u0028\\u0027documents\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\u0027,\\u0027{36974d54-7289-477f-8407-f203f5f3f499}\\u0027,\\u0027Board\\u0027,\\u00272017 Meeting Minutes\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027,\\u0027\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027\\u0029;','HiddenScript':'!offlineBtnText','Description':'Synchronize items and make them available offline.'},{'Command':'ExportToSpreadsheet','ClickScript':'javaScript:ExportList\\u0028\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002f_vti_bin\\\\u002fowssvr.dll?CS=65001\\\\u0026Using=_layouts\\\\u002f15\\\\u002fquery.iqy\\\\u0026List=\\\\u00257B36974D54\\\\u00252D7289\\\\u00252D477F\\\\u00252D8407\\\\u00252DF203F5F3F499\\\\u00257D\\\\u0026View=\\\\u00257B6B982743\\\\u00252DACEB\\\\u00252D457F\\\\u00252D96B7\\\\u00252DD1E33DA995EB\\\\u00257D\\\\u0026RootFolder=\\\\u00252FAbout\\\\u00252DUs\\\\u00252FBoard\\\\u00252FDocuments\\\\u0026CacheControl=1\\u0027\\u0029','LabelText':'Export to Spreadsheet','Description':'Analyze items with a spreadsheet application.'}]";
+toolbarData['ViewDropDownOptions']="{showRepairView : false, showMergeView : false, showEditView: false, showCreateView: false, showApproverView:  false, listId: '{36974D54-7289-477F-8407-F203F5F3F499}', viewId: '{6B982743-ACEB-457F-96B7-D1E33DA995EB}', viewParameters: ''}";
+toolbarData['ViewId']='6b982743-aceb-457f-96b7-d1e33da995eb';
 toolbarData['ViewName']='';
 toolbarData['ViewReadOnly']='false';
 toolbarData['BaseViewId']='1';
@@ -2468,6 +1887,690 @@ ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ3, "sp.ribbon.js");
           ctx.Templates = {};
           ctx.ListData = WPQ3ListData;
           ctx.ListSchema = WPQ3SchemaData;
+          ctx.BaseViewID = 1;
+          ctx.ListTemplateType = 101;
+          
+          ctx.existingServerFilterHash = ajaxNavigate.getParam("ServerFilter");
+          if (null != ctx.existingServerFilterHash) {
+            ctx.existingServerFilterHash = ctx.existingServerFilterHash.replace(/-/g, '&').replace(/&&/g, '-');
+            var serverFilterRootFolder = GetUrlKeyValue("RootFolder", true,ctx.existingServerFilterHash);
+            var currentRootFolder = GetUrlKeyValue("RootFolder", true);
+            if("" == serverFilterRootFolder && "" != currentRootFolder)
+            {
+              ctx.existingServerFilterHash += "&RootFolder=" + currentRootFolder;
+            }
+            var uri=new URI(ajaxNavigate.get_href());
+            uri.setFragment("");
+            uri.setQuery(ctx.existingServerFilterHash);
+            STSNavigate(uri.getString());
+          }
+          
+              ctx.listBaseType = 1;
+          
+            ctx.noGroupCollapse = true;
+          
+          ctx.NavigateForFormsPages = false;
+          ctx.BasePermissions = {ManageLists: false, ManagePersonalViews: false, OpenItems: false};
+          ctx.CurrentUserIsSiteAdmin = false;
+          ctx.IsAppWeb = false;
+          ctx.AllowGridMode = false;
+          ctx.inGridMode = false;
+          ctx.listTemplate = "101";
+          ctx.listName = "{36974D54-7289-477F-8407-F203F5F3F499}";
+          ctx.rootFolder = "";
+          ctx.view = "{6B982743-ACEB-457F-96B7-D1E33DA995EB}";
+          ctx.viewTitle = "";
+          ctx.listUrlDir = "/About-Us/Board/Documents";
+          ctx.HttpPath = "https://www.lcb.pa.gov/About-Us/Board/_vti_bin/owssvr.dll?CS=65001";
+          ctx.HttpRoot = "https://www.lcb.pa.gov/About-Us/Board";
+          ctx.imagesPath = "/_layouts/15/images/";
+          ctx.PortalUrl = "";
+          ctx.SendToLocationName = "";
+          ctx.SendToLocationUrl = "";
+          
+              ctx.RecycleBinEnabled = 1;
+            
+          ctx.OfficialFileName = "";
+          ctx.OfficialFileNames = "";
+          ctx.WriteSecurity = "1";
+          ctx.SiteTitle = "Board";
+          ctx.ListTitle = "2017 Meeting Minutes";
+          if (ctx.PortalUrl == "") ctx.PortalUrl = null;
+          ctx.displayFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=4&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D";
+          ctx.newFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=8&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D&RootFolder=";
+          ctx.editFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=6&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D";
+          ctx.isWebEditorPreview = 0;
+          ctx.ctxId = 428;
+          ctx.isXslView = true;
+          ctx.IsClientRendering = true;
+          if (g_ViewIdToViewCounterMap["{6B982743-ACEB-457F-96B7-D1E33DA995EB}"] == null)
+              g_ViewIdToViewCounterMap["{6B982743-ACEB-457F-96B7-D1E33DA995EB}"]= 428;
+          ctx.CurrentUserId = -1;
+          
+            ctx.verEnabled = 1;
+          
+          ctx.RegionalSettingsTimeZoneBias = "300";
+          
+            ctx.AllowCreateFolder = true;
+          
+          ctx428 = ctx;
+          g_ctxDict['ctx428'] = ctx;
+      
+        function IsSharePointOpenDocuments( test )
+        {
+          if (test instanceof Array)
+            return false;
+          else
+            return (test != null) && typeof(test) == 'object';
+        }
+        var EditDocumentButton = [];
+        try {EditDocumentButton = new CreateObject("SharePoint.OpenDocuments.3");}
+        catch(err){}
+        if (IsSharePointOpenDocuments(EditDocumentButton))
+          fNewDoc3 = true;
+        else
+        {
+          try {EditDocumentButton = new CreateObject("SharePoint.OpenDocuments.2");}
+          catch(err){}
+          if (IsSharePointOpenDocuments(EditDocumentButton))
+            fNewDoc2 = true;
+          else
+          {
+            try {EditDocumentButton = new CreateObject("SharePoint.OpenDocuments.1");}
+            catch(err){}
+          }
+        }
+        fNewDoc = IsSharePointOpenDocuments(EditDocumentButton);
+      
+      ctx428.bInitialRender = true;
+      RenderListView(ctx428, 'WPQ3');
+      ctx428.bInitialRender = false;
+    var WPQ2ListData = { "Row" : 
+[{
+"ID": "96",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fApril 19, 2017.pdf",
+"FileLeafRef": "April 19, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "5\u002f3\u002f2017 12:15 PM",
+"Modified.FriendlyDisplay": "0|May 3, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "95",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fApril 5, 2017.pdf",
+"FileLeafRef": "April 5, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "4\u002f19\u002f2017 2:39 PM",
+"Modified.FriendlyDisplay": "0|April 19, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "102",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fAugust 2, 2017.pdf",
+"FileLeafRef": "August 2, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "8\u002f23\u002f2017 11:55 AM",
+"Modified.FriendlyDisplay": "0|August 23, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "103",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fAugust 23, 2017.pdf",
+"FileLeafRef": "August 23, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "9\u002f13\u002f2017 12:19 PM",
+"Modified.FriendlyDisplay": "0|September 13, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "111",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fDecember 20, 2017.pdf",
+"FileLeafRef": "December 20, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "1\u002f17\u002f2018 12:06 PM",
+"Modified.FriendlyDisplay": "0|January 17, 2018",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "110",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fDecember 6, 2017.pdf",
+"FileLeafRef": "December 6, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "12\u002f20\u002f2017 11:29 AM",
+"Modified.FriendlyDisplay": "0|December 20, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "91",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fFebruary 1, 2017.pdf",
+"FileLeafRef": "February 1, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "2\u002f15\u002f2017 12:00 PM",
+"Modified.FriendlyDisplay": "0|February 15, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "92",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fFebruary 15, 2017.pdf",
+"FileLeafRef": "February 15, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "3\u002f8\u002f2017 11:33 AM",
+"Modified.FriendlyDisplay": "0|March 8, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "90",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJanuary 18, 2017.pdf",
+"FileLeafRef": "January 18, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "2\u002f1\u002f2017 12:00 PM",
+"Modified.FriendlyDisplay": "0|February 1, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "101",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJuly 19, 2017.pdf",
+"FileLeafRef": "July 19, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "8\u002f2\u002f2017 11:58 AM",
+"Modified.FriendlyDisplay": "0|August 2, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "100",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJune 28, 2017.pdf",
+"FileLeafRef": "June 28, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "7\u002f19\u002f2017 11:38 AM",
+"Modified.FriendlyDisplay": "0|July 19, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "99",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fJune 7, 2017.pdf",
+"FileLeafRef": "June 7, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "6\u002f28\u002f2017 11:38 AM",
+"Modified.FriendlyDisplay": "0|June 28, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "94",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fMarch 22, 2017.pdf",
+"FileLeafRef": "March 22, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "4\u002f5\u002f2017 11:48 AM",
+"Modified.FriendlyDisplay": "0|April 5, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "98",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fMay 17, 2017.pdf",
+"FileLeafRef": "May 17, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "6\u002f7\u002f2017 12:02 PM",
+"Modified.FriendlyDisplay": "0|June 7, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "97",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fMay 3, 2017.pdf",
+"FileLeafRef": "May 3, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "5\u002f17\u002f2017 12:05 PM",
+"Modified.FriendlyDisplay": "0|May 17, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "108",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fNovember 1, 2017.pdf",
+"FileLeafRef": "November 1, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "11\u002f15\u002f2017 12:48 PM",
+"Modified.FriendlyDisplay": "0|November 15, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "109",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fNovember 15, 2017.pdf",
+"FileLeafRef": "November 15, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "12\u002f6\u002f2017 12:02 PM",
+"Modified.FriendlyDisplay": "0|December 6, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "106",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fOctober 11, 2017.pdf",
+"FileLeafRef": "October 11, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "10\u002f23\u002f2017 9:43 AM",
+"Modified.FriendlyDisplay": "0|October 23, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "107",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fOctober 20, 2017.pdf",
+"FileLeafRef": "October 20, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "11\u002f1\u002f2017 12:32 PM",
+"Modified.FriendlyDisplay": "0|November 1, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "104",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fSeptember 13, 2017.pdf",
+"FileLeafRef": "September 13, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "9\u002f27\u002f2017 11:48 AM",
+"Modified.FriendlyDisplay": "0|September 27, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+,{
+"ID": "105",
+"PermMask": "0x1000030041",
+"FSObjType": "0",
+"HTML_x0020_File_x0020_Type": "",
+"File_x0020_Type": "pdf",
+"File_x0020_Type.mapapp": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapcon": "",
+"HTML_x0020_File_x0020_Type.File_x0020_Type.mapico": "icpdf.png",
+"serverurl.progid": "",
+"ServerRedirectedEmbedUrl": "",
+"File_x0020_Type.progid": "",
+"File_x0020_Type.url": "FALSE",
+"FileRef": "\u002fAbout-Us\u002fBoard\u002fDocuments\u002fSeptember 27, 2017.pdf",
+"FileLeafRef": "September 27, 2017.pdf",
+"CheckoutUser": "",
+"CheckedOutUserId": "",
+"IsCheckedoutToLocal": "0",
+"Created_x0020_Date.ifnew": "",
+"ContentTypeId": "0x01010047A6CDC32985684C8985BAACF6063B44",
+"Modified": "10\u002f11\u002f2017 11:39 AM",
+"Modified.FriendlyDisplay": "0|October 11, 2017",
+"Editor": [{"id":"1073741823","title":"System Account","picture":""}]
+}
+],"FirstRow" : 1,
+"LastRow" : 21
+,"FilterLink" : "?"
+,"ForceNoHierarchy" : "1"
+,"HierarchyHasIndention" : ""
+
+};var WPQ2SchemaData = { "Field": [ 
+{"Name": "DocIcon",
+"FieldType": "Computed",
+"RealFieldName": "DocIcon",
+"DisplayName": "Type",
+"ID": "081c6e4c-5c14-4f20-b23e-1a71ceb6a67c",
+"ReadOnly": "TRUE",
+"ClassInfo": "Icon",
+"Type": "Computed",
+"AllowGridEditing": "FALSE"}
+,{"Name": "LinkFilename",
+"FieldType": "Computed",
+"RealFieldName": "FileLeafRef",
+"DisplayName": "Name",
+"ID": "5cc6dc79-3710-4374-b433-61cb4a686c12",
+"ClassInfo": "Menu",
+"Type": "Computed",
+"Filterable": "FALSE",
+"listItemMenu": "TRUE",
+"CalloutMenu": "TRUE",
+"AllowGridEditing": "TRUE"}
+,{"Name": "Modified",
+"FieldType": "DateTime",
+"RealFieldName": "Modified",
+"DisplayName": "Modified",
+"ID": "28cf69c5-fa48-462a-b5cd-27b6f9d2bd5f",
+"ReadOnly": "TRUE",
+"Type": "DateTime",
+"AllowGridEditing": "FALSE"}
+,{"Name": "Editor",
+"FieldType": "User",
+"RealFieldName": "Editor",
+"DisplayName": "Modified By",
+"ID": "d31655d1-1d5b-4511-95a1-7a09e9b75bf2",
+"ReadOnly": "TRUE",
+"ImnHeader": "TRUE",
+"DefaultRender": "1",
+"Type": "User",
+"AllowGridEditing": "FALSE"}
+],"LCID" : "1033","Userid" : ""
+,"PagePath" : "/About-Us/Board/Pages/Public-Meetings.aspx"
+,"ShowWebPart" : ""
+,"View" : "{B1692D68-0638-405B-B4FD-3A8C40498E30}"
+,"RootFolderParam" : "View={b1692d68-0638-405b-b4fd-3a8c40498e30}&"
+,"FieldSortParam" : ""
+,"HttpVDir" : "https://www.lcb.pa.gov/About-Us/Board"
+,"IsDocLib" : "1"
+,"UIVersion" : "15","NoListItem" : "There are no items to show in this view of the \"2017 Meeting Minutes\" document library.","NoListItemHowTo" : "To add a new item, click \"New\" or \"Upload\".","DefaultItemOpen" : "1","ForceCheckout" : "0","Direction" : "none","TabularView" : "1","PresenceAlt" : "No presence information"
+,"UserDispUrl" : "/About-Us/Board/_layouts/15/userdisp.aspx"
+,"SelectedID" : "-1"
+,"Toolbar" : "Standard"
+};function _initTRAWebPartWPQ2()
+{var toolbarData = new Object();toolbarData['ToolbarData'] = "[{'Command':'OpenWithExplorer','ClickScript':'CoreInvoke\\u0028\\u0027NavigateHttpFolder\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027, \\u0027_blank\\u0027\\u0029;','HiddenScript':'!\\u0028SupportsNavigateHttpFolder\\u0028\\u0029\\u0029','LabelText':'Open with Windows Explorer','Description':'Drag and drop files into this library.'},{'Command':'ConnectToClient','ClickScript':'javaScript:ExportHailStorm\\u0028\\u0027documents\\u0027,\\u0027https:\\\\u002f\\\\u002fwww.lcb.pa.gov\\\\u002fAbout-Us\\\\u002fBoard\\u0027,\\u0027{36974d54-7289-477f-8407-f203f5f3f499}\\u0027,\\u0027Board\\u0027,\\u00272017 Meeting Minutes\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027,\\u0027\\u0027,\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002fDocuments\\u0027\\u0029;','HiddenScript':'!offlineBtnText','Description':'Synchronize items and make them available offline.'},{'Command':'ExportToSpreadsheet','ClickScript':'javaScript:ExportList\\u0028\\u0027\\\\u002fAbout-Us\\\\u002fBoard\\\\u002f_vti_bin\\\\u002fowssvr.dll?CS=65001\\\\u0026Using=_layouts\\\\u002f15\\\\u002fquery.iqy\\\\u0026List=\\\\u00257B36974D54\\\\u00252D7289\\\\u00252D477F\\\\u00252D8407\\\\u00252DF203F5F3F499\\\\u00257D\\\\u0026View=\\\\u00257BB1692D68\\\\u00252D0638\\\\u00252D405B\\\\u00252DB4FD\\\\u00252D3A8C40498E30\\\\u00257D\\\\u0026RootFolder=\\\\u00252FAbout\\\\u00252DUs\\\\u00252FBoard\\\\u00252FDocuments\\\\u0026CacheControl=1\\u0027\\u0029','LabelText':'Export to Spreadsheet','Description':'Analyze items with a spreadsheet application.'}]";
+toolbarData['ViewDropDownOptions']="{showRepairView : false, showMergeView : false, showEditView: false, showCreateView: false, showApproverView:  false, listId: '{36974D54-7289-477F-8407-F203F5F3F499}', viewId: '{B1692D68-0638-405B-B4FD-3A8C40498E30}', viewParameters: ''}";
+toolbarData['ViewId']='b1692d68-0638-405b-b4fd-3a8c40498e30';
+toolbarData['ViewName']='';
+toolbarData['ViewReadOnly']='false';
+toolbarData['BaseViewId']='1';
+toolbarData['ListId']='36974d54-7289-477f-8407-f203f5f3f499';
+toolbarData['ListEnableAttachments']='False';
+toolbarData['ListBaseType']='1';
+toolbarData['ListTemplateType']='101';
+toolbarData['ListPermissions']='{High:16,Low:196673}';
+toolbarData['ListFolderPermissions']='{High:16,Low:196673}';
+toolbarData['ListHasExternalDataSource']='False';
+toolbarData['ServerRelativeWebUrl']='\u002fAbout-Us\u002fBoard';
+toolbarData['IsAppWeb']=false;
+SP.Ribbon.PageManager.get_instance().addPageComponent(new SP.Ribbon.DocLibWebPartPageComponent('WebPartWPQ2',toolbarData));
+}
+ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ2, "sp.ribbon.js");
+          ctx = new ContextInfo();
+          ctx.wpq= "WPQ2";
+          ctx.Templates = {};
+          ctx.ListData = WPQ2ListData;
+          ctx.ListSchema = WPQ2SchemaData;
           ctx.BaseViewID = 1;
           ctx.ListTemplateType = 101;
           
@@ -2521,11 +2624,11 @@ ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ3, "sp.ribbon.js");
           ctx.newFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=8&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D&RootFolder=";
           ctx.editFormUrl = "https://www.lcb.pa.gov/About-Us/Board/_layouts/15/listform.aspx?PageType=6&ListId=%7B36974D54%2D7289%2D477F%2D8407%2DF203F5F3F499%7D";
           ctx.isWebEditorPreview = 0;
-          ctx.ctxId = 35;
+          ctx.ctxId = 427;
           ctx.isXslView = true;
           ctx.IsClientRendering = true;
           if (g_ViewIdToViewCounterMap["{B1692D68-0638-405B-B4FD-3A8C40498E30}"] == null)
-              g_ViewIdToViewCounterMap["{B1692D68-0638-405B-B4FD-3A8C40498E30}"]= 35;
+              g_ViewIdToViewCounterMap["{B1692D68-0638-405B-B4FD-3A8C40498E30}"]= 427;
           ctx.CurrentUserId = -1;
           
             ctx.verEnabled = 1;
@@ -2534,8 +2637,8 @@ ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ3, "sp.ribbon.js");
           
             ctx.AllowCreateFolder = true;
           
-          ctx35 = ctx;
-          g_ctxDict['ctx35'] = ctx;
+          ctx427 = ctx;
+          g_ctxDict['ctx427'] = ctx;
       
         function IsSharePointOpenDocuments( test )
         {
@@ -2563,10 +2666,10 @@ ExecuteOrDelayUntilScriptLoaded(_initTRAWebPartWPQ3, "sp.ribbon.js");
         }
         fNewDoc = IsSharePointOpenDocuments(EditDocumentButton);
       
-      ctx35.bInitialRender = true;
-      RenderListView(ctx35, 'WPQ3');
-      ctx35.bInitialRender = false;
+      ctx427.bInitialRender = true;
+      RenderListView(ctx427, 'WPQ2');
+      ctx427.bInitialRender = false;
     //]]>
 </script>
-</form><span id="DeltaPlaceHolderUtilityContent"></span></body>
-</html>
+</form><span id="DeltaPlaceHolderUtilityContent"></span><div id="goog-gt-tt" class="skiptranslate" dir="ltr"><div style="padding: 8px;"><div><div class="logo"><img src="./PLCB Public Meetings_files/translate_24dp.png" width="20" height="20" alt="Google Translate"></div></div></div><div class="top" style="padding: 8px; float: left; width: 100%;"><h1 class="title gray">Original text</h1></div><div class="middle" style="padding: 8px;"><div class="original-text"></div></div><div class="bottom" style="padding: 8px;"><div class="activity-links"><span class="activity-link">Contribute a better translation</span><span class="activity-link"></span></div><div class="started-activity-container"><hr style="color: #CCC; background-color: #CCC; height: 1px; border: none;"><div class="activity-root"></div></div></div><div class="status-message" style="display: none;"></div></div>
+<div class="goog-te-spinner-pos"><div class="goog-te-spinner-animation"><svg xmlns="http://www.w3.org/2000/svg" class="goog-te-spinner" width="96px" height="96px" viewBox="0 0 66 66"><circle class="goog-te-spinner-path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle></svg></div></div><iframe frameborder="0" class="goog-te-menu-frame skiptranslate embed-responsive" title="Language Translate Widget" style="visibility: visible; box-sizing: content-box; width: 1030px; height: 263px; display: none;" src="./PLCB Public Meetings_files/saved_resource(3).html"></iframe></body></html>

--- a/tests/test_pa_liquorboard.py
+++ b/tests/test_pa_liquorboard.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from os.path import dirname, join
 
+from city_scrapers_core.constants import BOARD
 from city_scrapers_core.utils import file_response
 from freezegun import freeze_time
 
@@ -12,7 +13,7 @@ test_response = file_response(
 )
 spider = PaLiquorboardSpider()
 
-freezer = freeze_time("2019-02-08")
+freezer = freeze_time("2020-01-02")
 freezer.start()
 
 parsed_items = [item for item in spider.parse(test_response)]
@@ -20,5 +21,44 @@ parsed_items = [item for item in spider.parse(test_response)]
 freezer.stop()
 
 
+def test_description():
+    assert parsed_items[0]["description"] == ""
+
+
 def test_start():
-    assert parsed_items[0]["start"] > datetime(2000, 1, 1, 0, 0)
+    assert parsed_items[0]["start"] == datetime(2020, 2, 12, 11, 0)
+
+
+def test_id():
+    assert parsed_items[0]["id"] == "pa_liquorboard/202002121100/x/"
+
+
+def test_status():
+    assert parsed_items[0]["status"] == "tentative"
+
+
+def test_location():
+    assert parsed_items[0]["location"] == {
+        "name": "Pennsylvania Liquor Control Board Headquarters",
+        "address": "Room 117, 604 Northwest Office Building, Harrisburg, PA 17124"
+    }
+
+
+def test_source():
+    ref = "https://www.lcb.pa.gov/About-Us/Board/Pages/Public-Meetings.aspx"
+    assert parsed_items[0]["source"] == ref
+
+
+def test_links():
+    assert parsed_items[0]["links"][0] == {
+        "href": "",
+        "title": ""
+    }
+
+
+def test_classification():
+    assert parsed_items[0]["classification"] == BOARD
+
+
+def test_all_day():
+    assert parsed_items[0]["all_day"] is False

--- a/tests/test_pa_liquorboard.py
+++ b/tests/test_pa_liquorboard.py
@@ -49,13 +49,6 @@ def test_source():
     assert parsed_items[0]["source"] == ref
 
 
-def test_links():
-    assert parsed_items[0]["links"][0] == {
-        "href": "",
-        "title": ""
-    }
-
-
 def test_classification():
     assert parsed_items[0]["classification"] == BOARD
 


### PR DESCRIPTION
Fix an issue where get_status was broken on pa_liquorboard causing it
to yield no meetings. The issue was recreated and then fixed. I think
the crux of the problem had to do with strings like "-" getting passed
into our datetime parser.

I also added new tests to try and catch issues like this in the future.